### PR TITLE
feat(hostname): can now override hostname of device by passing -h

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: run the tests
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
+      
+      - uses: codecov/codecov-action@v1.0.14
+        name: Upload Coverage Results
+        
       # Runs a single command using the runners shell
       - name: build go
         if: ${{ matrix.os == 'windows-2019' }}

--- a/internal/amt/commands_test.go
+++ b/internal/amt/commands_test.go
@@ -1,3 +1,6 @@
+//go:build amt
+// +build amt
+
 /*********************************************************************
  * Copyright (c) Intel Corporation 2021
  * SPDX-License-Identifier: Apache-2.0

--- a/internal/rpc/flags.go
+++ b/internal/rpc/flags.go
@@ -16,74 +16,141 @@ import (
 
 // Flags holds data received from the command line
 type Flags struct {
-	URL           string
-	DNS           string
-	Proxy         string
-	Command       string
-	SkipCertCheck bool
-	Verbose       bool
+	commandLineArgs      []string
+	URL                  string
+	DNS                  string
+	Hostname             string
+	Proxy                string
+	Command              string
+	Profile              string
+	SkipCertCheck        bool
+	Verbose              bool
+	amtInfoCommand       *flag.FlagSet
+	amtActivateCommand   *flag.FlagSet
+	amtDeactivateCommand *flag.FlagSet
+}
+
+func NewFlags(args []string) *Flags {
+	flags := &Flags{}
+	flags.commandLineArgs = args
+	flags.amtInfoCommand = flag.NewFlagSet("amtinfo", flag.ExitOnError)
+	flags.amtActivateCommand = flag.NewFlagSet("activate", flag.ExitOnError)
+	flags.amtDeactivateCommand = flag.NewFlagSet("deactivate", flag.ExitOnError)
+	flags.setupCommonFlags()
+	return flags
 }
 
 // ParseFlags is used for understanding the command line flags
-func (f Flags) ParseFlags() (Flags, error) {
+func (f *Flags) ParseFlags() (string, bool) {
 
-	//required
-	urlPtr := flag.String("u", "", "websocker server address")
-	cmdPtr := flag.String("c", "", "server command")
-	//optional
-	proxyPtr := flag.String("p", "", "proxy address and port")
-	dnsPtr := flag.String("d", "", "dns suffix override")
-	verbosePtr := flag.Bool("v", false, "verbose output")
-	skipCertPtr := flag.Bool("n", false, "skip websocket server certificate verification")
-	//informational
-	versionPtr := flag.Bool("version", false, "version of rpc")
-
-	amtInfoCommand := flag.NewFlagSet("amtinfo", flag.ExitOnError)
-
-	//amtinfoStr := flag.String("", "", "AMT info on an <item>")
-
-	flag.Parse()
-
-	if *verbosePtr {
-		f.Verbose = true
+	if len(f.commandLineArgs) > 1 {
+		switch f.commandLineArgs[1] {
+		case "amtinfo":
+			f.handleAMTInfo(f.amtInfoCommand)
+			return "amtinfo", false //we want to exit the program
+		case "activate":
+			success := f.handleActivateCommand()
+			return "activate", success
+		case "deactivate":
+			success := f.handleDeactivateCommand()
+			return "deactivate", success
+		case "version":
+			println(strings.ToUpper(utils.ProjectName))
+			println("Protocol " + utils.ProtocolVersion)
+			return "version", false
+		default:
+			f.printUsage()
+			return "", false
+		}
 	}
-	if *skipCertPtr {
-		f.SkipCertCheck = true
-	}
-	if *versionPtr {
-		println(strings.ToUpper(utils.ProjectName))
-		println("Protocol " + utils.ProtocolVersion)
-		os.Exit(1)
-	}
-	amt := amt.Command{}
-	result, err := amt.Initialize()
-	if result == false || err != nil {
-		println("Unable to launch application. Please ensure that Intel ME is present, the MEI driver is installed and that this application is run with administrator or root privileges.")
-		os.Exit(1)
-	}
+	f.printUsage()
+	return "", false
 
-	f.handleAMTInfo(amtInfoCommand)
-
-	if *urlPtr == "" || *cmdPtr == "" {
-		flag.PrintDefaults()
-		os.Exit(1)
-	}
-
-	f.URL = *urlPtr
-	f.Command = *cmdPtr
-
-	if *dnsPtr != "" {
-		f.DNS = *dnsPtr
-	}
-	if *proxyPtr != "" {
-		f.Proxy = *proxyPtr
-	}
-	return f, nil
+}
+func (f *Flags) printUsage() string {
+	usage := "\nRemote Provisioning Client (RPC) - used for activation, deactivation, and status of AMT\n\n"
+	usage = usage + "Usage: rpc COMMAND [OPTIONS]\n\n"
+	usage = usage + "Supported Commands:\n"
+	usage = usage + "  activate   Activate this device with a specified profile\n"
+	usage = usage + "             Example: ./rpc activate -u wss://server/activate --profile acmprofile\n"
+	usage = usage + "  deactivate Deactivates this device. AMT password is required\n"
+	usage = usage + "             Example: ./rpc deactivate -u wss://server/activate\n"
+	usage = usage + "  amtinfo    Displays information about AMT status and configuration\n"
+	usage = usage + "             Example: ./rpc amtinfo\n"
+	usage = usage + "  version    Displays the current version of RPC and the RPC Protocol version\n"
+	usage = usage + "             Example: ./rpc version\n"
+	usage = usage + "\nRun 'rpc COMMAND' for more information on a command.\n"
+	fmt.Println(usage)
+	return usage
 }
 
-func (f Flags) handleAMTInfo(amtInfoCommand *flag.FlagSet) {
+func (f *Flags) setupCommonFlags() {
+	for _, fs := range []*flag.FlagSet{f.amtActivateCommand, f.amtDeactivateCommand} {
+		fs.StringVar(&f.URL, "u", "", "websocket address of server to activate against") //required
+		fs.BoolVar(&f.SkipCertCheck, "n", false, "skip websocket server certificate verification")
+		fs.StringVar(&f.Proxy, "p", "", "proxy address and port")
+		fs.BoolVar(&f.Verbose, "v", false, "verbose output")
+	}
+}
+func (f *Flags) handleActivateCommand() bool {
+	f.amtActivateCommand.StringVar(&f.DNS, "d", "", "dns suffix override")
+	f.amtActivateCommand.StringVar(&f.Hostname, "h", "", "hostname override")
+	f.amtActivateCommand.StringVar(&f.Profile, "profile", "", "name of the profile to use")
+	if len(f.commandLineArgs) == 2 {
+		f.amtActivateCommand.PrintDefaults()
+		return false
+	}
+	f.amtActivateCommand.Parse(f.commandLineArgs[2:])
 
-	amtInfoAllPtr := amtInfoCommand.Bool("all", false, "All AMT Info")
+	if f.amtActivateCommand.Parsed() {
+		if f.URL == "" {
+			fmt.Println("-u flag is required and cannot be empty")
+			f.amtActivateCommand.Usage()
+			return false
+		}
+		if f.Profile == "" {
+			fmt.Println("-profile flag is required and cannot be empty")
+			f.amtActivateCommand.Usage()
+			return false
+		}
+	}
+	f.Command = "activate --profile " + f.Profile
+	return true
+}
+func (f *Flags) handleDeactivateCommand() bool {
+	passwordPtr := f.amtDeactivateCommand.String("password", "", "AMT password")
+	forcePtr := f.amtDeactivateCommand.Bool("f", false, "force deactivate even if device is not registered with a server")
+
+	if len(f.commandLineArgs) == 2 {
+		f.amtDeactivateCommand.PrintDefaults()
+		return false
+	}
+	f.amtDeactivateCommand.Parse(f.commandLineArgs[2:])
+
+	if f.amtDeactivateCommand.Parsed() {
+		if f.URL == "" {
+			fmt.Println("-u flag is required and cannot be empty")
+			f.amtDeactivateCommand.Usage()
+			return false
+		}
+		if *passwordPtr == "" {
+			fmt.Println("Please enter AMT Password: ")
+			var password string
+			// Taking input from user
+			_, err := fmt.Scanln(&password)
+			if password == "" || err != nil {
+				return false
+			}
+			*passwordPtr = password
+		}
+		f.Command = "deactivate --password " + *passwordPtr
+		if *forcePtr {
+			f.Command = f.Command + " -f"
+		}
+	}
+	return true
+}
+func (f *Flags) handleAMTInfo(amtInfoCommand *flag.FlagSet) {
 	amtInfoVerPtr := amtInfoCommand.Bool("ver", false, "BIOS Version")
 	amtInfoBldPtr := amtInfoCommand.Bool("bld", false, "Build Number")
 	amtInfoSkuPtr := amtInfoCommand.Bool("sku", false, "Product SKU")
@@ -94,102 +161,92 @@ func (f Flags) handleAMTInfo(amtInfoCommand *flag.FlagSet) {
 	amtInfoRasPtr := amtInfoCommand.Bool("ras", false, "Remote Access Status")
 	amtInfoLanPtr := amtInfoCommand.Bool("lan", false, "LAN Settings")
 	amtInfoHostnamePtr := amtInfoCommand.Bool("hostname", false, "OS Hostname")
+	if len(f.commandLineArgs) == 2 {
+		*amtInfoVerPtr = true
+		*amtInfoBldPtr = true
+		*amtInfoSkuPtr = true
+		*amtInfoUUIDPtr = true
+		*amtInfoModePtr = true
+		*amtInfoDNSPtr = true
+		*amtInfoCertPtr = false
+		*amtInfoRasPtr = true
+		*amtInfoLanPtr = true
+		*amtInfoHostnamePtr = true
+	}
+	amtInfoCommand.Parse(f.commandLineArgs[2:])
 
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "amtinfo":
-			amtInfoCommand.Parse(os.Args[2:])
+	if amtInfoCommand.Parsed() {
+		amt := amt.Command{}
+		if *amtInfoVerPtr {
+			result, _ := amt.GetVersionDataFromME("AMT")
+			println("Version			: " + result)
+		}
+		if *amtInfoBldPtr {
+			result, _ := amt.GetVersionDataFromME("Build Number")
+			println("Build Number		: " + result)
+		}
+		if *amtInfoSkuPtr {
+			result, _ := amt.GetVersionDataFromME("Sku")
+			println("SKU			: " + result)
+		}
+		if *amtInfoUUIDPtr {
+			result, _ := amt.GetUUID()
+			println("UUID			: " + result)
+		}
+		if *amtInfoModePtr {
+			result, _ := amt.GetControlMode()
+			println("Control Mode		: " + string(utils.InterpretControlMode(result)))
+		}
+		if *amtInfoDNSPtr {
+			result, _ := amt.GetDNSSuffix()
+			println("DNS Suffix		: " + string(result))
+			result, _ = amt.GetOSDNSSuffix()
+			fmt.Println("DNS Suffix (OS)		: " + result)
+		}
+		if *amtInfoHostnamePtr {
+			result, _ := os.Hostname()
+			println("Hostname (OS)		: " + string(result))
 		}
 
-		if amtInfoCommand.Parsed() {
-			if *amtInfoAllPtr {
-				*amtInfoVerPtr = true
-				*amtInfoBldPtr = true
-				*amtInfoSkuPtr = true
-				*amtInfoUUIDPtr = true
-				*amtInfoModePtr = true
-				*amtInfoDNSPtr = true
-				*amtInfoCertPtr = true
-				*amtInfoRasPtr = true
-				*amtInfoLanPtr = true
-				*amtInfoHostnamePtr = true
-			}
-			amt := amt.Command{}
-			if *amtInfoVerPtr {
-				result, _ := amt.GetVersionDataFromME("AMT")
-				println("Version			: " + result)
-			}
-			if *amtInfoBldPtr {
-				result, _ := amt.GetVersionDataFromME("Build Number")
-				println("Build Number		: " + result)
-			}
-			if *amtInfoSkuPtr {
-				result, _ := amt.GetVersionDataFromME("Sku")
-				println("SKU			: " + result)
-			}
-			if *amtInfoUUIDPtr {
-				result, _ := amt.GetUUID()
-				println("UUID			: " + result)
-			}
-			if *amtInfoModePtr {
-				result, _ := amt.GetControlMode()
-				println("Control Mode		: " + string(utils.InterpretControlMode(result)))
-			}
-			if *amtInfoDNSPtr {
-				result, _ := amt.GetDNSSuffix()
-				println("DNS Suffix		: " + string(result))
-				result, _ = amt.GetOSDNSSuffix()
-				fmt.Println("DNS Suffix (OS)		: " + result)
-			}
-			if *amtInfoHostnamePtr {
-				result, _ := os.Hostname()
-				println("Hostname (OS)		: " + string(result))
-			}
+		if *amtInfoRasPtr {
+			result, _ := amt.GetRemoteAccessConnectionStatus()
+			println("RAS Network      	: " + result.NetworkStatus)
+			println("RAS Remote Status	: " + result.RemoteStatus)
+			println("RAS Trigger      	: " + result.RemoteTrigger)
+			println("RAS MPS Hostname 	: " + result.MPSHostname)
+		}
+		if *amtInfoLanPtr {
+			wired, _ := amt.GetLANInterfaceSettings(false)
+			println("---Wired Adapter---")
+			println("DHCP Enabled 		: " + strconv.FormatBool(wired.DHCPEnabled))
+			println("DHCP Mode    		: " + wired.DHCPMode)
+			println("Link Status  		: " + wired.LinkStatus)
+			println("IP Address   		: " + wired.IPAddress)
+			println("MAC Address  		: " + wired.MACAddress)
 
-			if *amtInfoRasPtr {
-				result, _ := amt.GetRemoteAccessConnectionStatus()
-				println("RAS Network      	: " + result.NetworkStatus)
-				println("RAS Remote Status	: " + result.RemoteStatus)
-				println("RAS Trigger      	: " + result.RemoteTrigger)
-				println("RAS MPS Hostname 	: " + result.MPSHostname)
-			}
-			if *amtInfoLanPtr {
-				wired, _ := amt.GetLANInterfaceSettings(false)
-				println("---Wired Adapter---")
-				println("DHCP Enabled 		: " + strconv.FormatBool(wired.DHCPEnabled))
-				println("DHCP Mode    		: " + wired.DHCPMode)
-				println("Link Status  		: " + wired.LinkStatus)
-				println("IP Address   		: " + wired.IPAddress)
-				println("MAC Address  		: " + wired.MACAddress)
+			wireless, _ := amt.GetLANInterfaceSettings(true)
+			println("---Wireless Adapter---")
+			println("DHCP Enabled 		: " + strconv.FormatBool(wireless.DHCPEnabled))
+			println("DHCP Mode    		: " + wireless.DHCPMode)
+			println("Link Status  		: " + wireless.LinkStatus)
+			println("IP Address   		: " + wireless.IPAddress)
+			println("MAC Address  		: " + wireless.MACAddress)
+		}
+		if *amtInfoCertPtr {
+			result, _ := amt.GetCertificateHashes()
+			println("Certificate Hashes	:")
+			for _, v := range result {
 
-				wireless, _ := amt.GetLANInterfaceSettings(true)
-				println("---Wireless Adapter---")
-				println("DHCP Enabled 		: " + strconv.FormatBool(wireless.DHCPEnabled))
-				println("DHCP Mode    		: " + wireless.DHCPMode)
-				println("Link Status  		: " + wireless.LinkStatus)
-				println("IP Address   		: " + wireless.IPAddress)
-				println("MAC Address  		: " + wireless.MACAddress)
-			}
-			if *amtInfoCertPtr {
-				result, _ := amt.GetCertificateHashes()
-				println("Certificate Hashes	:")
-				for _, v := range result {
-
-					print(strings.Trim(v.Name, "\xab") + " (")
-					if v.IsDefault {
-						print("Default,")
-					}
-					if v.IsActive {
-						print("Active)")
-					}
-					println()
-					println("   " + v.Algorithm + ": " + v.Hash)
+				print(v.Name + " (")
+				if v.IsDefault {
+					print("Default,")
 				}
+				if v.IsActive {
+					print("Active)")
+				}
+				println()
+				println("   " + v.Algorithm + ": " + v.Hash)
 			}
-			// else {
-			// 	amtInfoCommand.PrintDefaults()
-			// }
-			os.Exit(1)
 		}
 	}
 }

--- a/internal/rpc/flags_test.go
+++ b/internal/rpc/flags_test.go
@@ -3,3 +3,195 @@
  * SPDX-License-Identifier: Apache-2.0
  **********************************************************************/
 package rpc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFlags(t *testing.T) {
+	args := []string{"./rpc"}
+	flags := NewFlags(args)
+	assert.NotNil(t, flags)
+}
+func TestPrintUsage(t *testing.T) {
+	args := []string{"./rpc"}
+	flags := NewFlags(args)
+	output := flags.printUsage()
+	usage := "\nRemote Provisioning Client (RPC) - used for activation, deactivation, and status of AMT\n\n"
+	usage = usage + "Usage: rpc COMMAND [OPTIONS]\n\n"
+	usage = usage + "Supported Commands:\n"
+	usage = usage + "  activate   Activate this device with a specified profile\n"
+	usage = usage + "             Example: ./rpc activate -u wss://server/activate --profile acmprofile\n"
+	usage = usage + "  deactivate Deactivates this device. AMT password is required\n"
+	usage = usage + "             Example: ./rpc deactivate -u wss://server/activate\n"
+	usage = usage + "  amtinfo    Displays information about AMT status and configuration\n"
+	usage = usage + "             Example: ./rpc amtinfo\n"
+	usage = usage + "  version    Displays the current version of RPC and the RPC Protocol version\n"
+	usage = usage + "             Example: ./rpc version\n"
+	usage = usage + "\nRun 'rpc COMMAND' for more information on a command.\n"
+	assert.Equal(t, usage, output)
+}
+
+func TestHandleActivateCommandNoFlags(t *testing.T) {
+	args := []string{"./rpc", "activate"}
+	flags := NewFlags(args)
+	success := flags.handleActivateCommand()
+	assert.False(t, success)
+}
+func TestHandleActivateCommand(t *testing.T) {
+	args := []string{"./rpc", "activate", "-u", "wss://localhost", "-profile", "profileName"}
+	flags := NewFlags(args)
+	expected := "activate --profile profileName"
+	success := flags.handleActivateCommand()
+	assert.True(t, success)
+	assert.Equal(t, "wss://localhost", flags.URL)
+	assert.Equal(t, "profileName", flags.Profile)
+	assert.Equal(t, expected, flags.Command)
+}
+
+func TestHandleActivateCommandNoURL(t *testing.T) {
+	args := []string{"./rpc", "activate", "-u", "wss://localhost"}
+	flags := NewFlags(args)
+	success := flags.handleActivateCommand()
+	assert.False(t, success)
+	assert.Equal(t, "wss://localhost", flags.URL)
+}
+
+func TestHandleActivateCommandNoProfile(t *testing.T) {
+	args := []string{"./rpc", "activate", "-profile", "profileName"}
+
+	flags := NewFlags(args)
+	success := flags.handleActivateCommand()
+	assert.False(t, success)
+	assert.Equal(t, "profileName", flags.Profile)
+}
+
+func TestHandleDeactivateCommandNoFlags(t *testing.T) {
+	args := []string{"./rpc", "deactivate"}
+
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.False(t, success)
+}
+func TestHandleDeactivateCommandNoPasswordPrompt(t *testing.T) {
+	args := []string{"./rpc", "deactivate", "-u", "wss://localhost"}
+	expected := "deactivate --password password"
+	input := []byte("password")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.True(t, success)
+	assert.Equal(t, expected, flags.Command)
+}
+func TestHandleDeactivateCommandNoPasswordPromptEmpy(t *testing.T) {
+	args := []string{"./rpc", "deactivate", "-u", "wss://localhost"}
+	input := []byte("")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = w.Write(input)
+	if err != nil {
+		t.Error(err)
+	}
+	w.Close()
+
+	stdin := os.Stdin
+	// Restore stdin right after the test.
+	defer func() { os.Stdin = stdin }()
+	os.Stdin = r
+
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.False(t, success)
+}
+func TestHandleDeactivateCommandNoURL(t *testing.T) {
+	args := []string{"./rpc", "deactivate", "--password", "password"}
+
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.False(t, success)
+}
+func TestHandleDeactivateCommand(t *testing.T) {
+	args := []string{"./rpc", "deactivate", "-u", "wss://localhost", "--password", "password"}
+	expected := "deactivate --password password"
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.True(t, success)
+	assert.Equal(t, "wss://localhost", flags.URL)
+	assert.Equal(t, expected, flags.Command)
+}
+func TestHandleDeactivateCommandWithForce(t *testing.T) {
+	args := []string{"./rpc", "deactivate", "-u", "wss://localhost", "--password", "password", "-f"}
+	expected := "deactivate --password password -f"
+	flags := NewFlags(args)
+	success := flags.handleDeactivateCommand()
+	assert.True(t, success)
+	assert.Equal(t, "wss://localhost", flags.URL)
+	assert.Equal(t, expected, flags.Command)
+}
+
+func TestParseFlagsDeactivate(t *testing.T) {
+	args := []string{"./rpc", "deactivate"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "deactivate", command)
+}
+
+func TestParseFlagsAMTInfo(t *testing.T) {
+	args := []string{"./rpc", "amtinfo"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "amtinfo", command)
+}
+func TestParseFlagsActivate(t *testing.T) {
+	args := []string{"./rpc", "activate"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "activate", command)
+}
+func TestParseFlagsVersion(t *testing.T) {
+	args := []string{"./rpc", "version"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "version", command)
+}
+
+func TestParseFlagsNone(t *testing.T) {
+	args := []string{"./rpc"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "", command)
+}
+
+func TestParseFlagsEmptyCommand(t *testing.T) {
+	args := []string{"./rpc", ""}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "", command)
+}

--- a/internal/rps/activation.go
+++ b/internal/rps/activation.go
@@ -51,7 +51,7 @@ type ActivationPayload struct {
 }
 
 // createPayload gathers data from ME to assemble required information for sending to the server
-func (p Payload) createPayload(dnsSuffix string) (ActivationPayload, error) {
+func (p Payload) createPayload(dnsSuffix string, hostname string) (ActivationPayload, error) {
 	payload := ActivationPayload{}
 	var err error
 	payload.Version, err = p.AMT.GetVersionDataFromME("AMT")
@@ -92,10 +92,13 @@ func (p Payload) createPayload(dnsSuffix string) (ActivationPayload, error) {
 			return payload, err
 		}
 	}
-
-	payload.Hostname, err = os.Hostname()
-	if err != nil {
-		return payload, err
+	if hostname != "" {
+		payload.Hostname = hostname
+	} else {
+		payload.Hostname, err = os.Hostname()
+		if err != nil {
+			return payload, err
+		}
 	}
 	payload.Client = utils.ClientName
 	hashes, err := p.AMT.GetCertificateHashes()
@@ -110,7 +113,7 @@ func (p Payload) createPayload(dnsSuffix string) (ActivationPayload, error) {
 }
 
 // CreateActivationRequest is used for assembling the message to request activation of a device
-func (p Payload) CreateActivationRequest(command string, dnsSuffix string) (Activation, error) {
+func (p Payload) CreateActivationRequest(command string, dnsSuffix string, hostname string) (Activation, error) {
 	activation := Activation{
 		Method:          command,
 		APIKey:          "key",
@@ -119,7 +122,7 @@ func (p Payload) CreateActivationRequest(command string, dnsSuffix string) (Acti
 		Status:          "ok",
 		Message:         "ok",
 	}
-	payload, err := p.createPayload(dnsSuffix)
+	payload, err := p.createPayload(dnsSuffix, hostname)
 	if err != nil {
 		return activation, err
 	}

--- a/internal/rps/activation_test.go
+++ b/internal/rps/activation_test.go
@@ -51,7 +51,7 @@ func init() {
 }
 func TestCreatePayload(t *testing.T) {
 	mebxDNSSuffix = "mebxdns"
-	result, err := p.createPayload("")
+	result, err := p.createPayload("", "")
 	assert.Equal(t, "Version", result.Version)
 	assert.Equal(t, "Version", result.Build)
 	assert.Equal(t, "Version", result.SKU)
@@ -67,19 +67,19 @@ func TestCreatePayload(t *testing.T) {
 }
 func TestCreatePayloadWithOSDNSSuffix(t *testing.T) {
 	mebxDNSSuffix = ""
-	result, err := p.createPayload("")
+	result, err := p.createPayload("", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "osdns", result.FQDN)
 }
 func TestCreatePayloadWithDNSSuffix(t *testing.T) {
 
-	result, err := p.createPayload("vprodemo.com")
+	result, err := p.createPayload("vprodemo.com", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "vprodemo.com", result.FQDN)
 }
 func TestCreateActivationRequestNoDNSSuffix(t *testing.T) {
 
-	result, err := p.CreateActivationRequest("method", "")
+	result, err := p.CreateActivationRequest("method", "", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "method", result.Method)
 	assert.Equal(t, "key", result.APIKey)
@@ -90,7 +90,7 @@ func TestCreateActivationRequestNoDNSSuffix(t *testing.T) {
 }
 func TestCreateActivationRequestWithDNSSuffix(t *testing.T) {
 
-	result, err := p.CreateActivationRequest("method", "vprodemo.com")
+	result, err := p.CreateActivationRequest("method", "vprodemo.com", "")
 	assert.NoError(t, err)
 	assert.Equal(t, "method", result.Method)
 	assert.Equal(t, "key", result.APIKey)

--- a/internal/rps/mps.go
+++ b/internal/rps/mps.go
@@ -50,7 +50,7 @@ func (amt *AMTActivationServer) Close() error {
 // Send is used for sending data to the RPS Server
 func (amt *AMTActivationServer) Send(data []byte) error {
 	log.Debug("sending message to RPS")
-	log.Trace(string(data))
+	// log.Trace(string(data))
 	err := amt.Conn.WriteMessage(websocket.TextMessage, data)
 	if err != nil {
 		return err
@@ -102,9 +102,9 @@ func (amt *AMTActivationServer) ProcessMessage(message []byte) []byte {
 			log.Info(activation.Message)
 
 		} else {
-			log.Info(statusMessage.Status)
-			log.Info(statusMessage.Network)
-			log.Info(statusMessage.CIRAConnection)
+			log.Info("Status: " + statusMessage.Status)
+			log.Info("Network: " + statusMessage.Network)
+			log.Info("CIRA: " + statusMessage.CIRAConnection)
 		}
 
 		return nil

--- a/pkg/heci/heci_linux_test.go
+++ b/pkg/heci/heci_linux_test.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && amt
+// +build linux,amt
 
 /*********************************************************************
  * Copyright (c) Intel Corporation 2021

--- a/pkg/heci/heci_windows_test.go
+++ b/pkg/heci/heci_windows_test.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && amt
+// +build windows,amt
 
 /*********************************************************************
  * Copyright (c) Intel Corporation 2021

--- a/pkg/pthi/commands_test.go
+++ b/pkg/pthi/commands_test.go
@@ -1,3 +1,6 @@
+//go:build amt
+// +build amt
+
 /*********************************************************************
  * Copyright (c) Intel Corporation 2021
  * SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
feat(hostname): can now override hostname of device by passing -h command line arg

This PR also refactors commands such that they are first class instead of a parsed string `./rpc activate` as opposed to `./rpc -c "activate"`.

Closes AB#2651