### PR TITLE
feat: add environment variable support for the following flags

### DIFF
--- a/internal/rpc/flags_test.go
+++ b/internal/rpc/flags_test.go
@@ -195,3 +195,39 @@ func TestParseFlagsEmptyCommand(t *testing.T) {
 	assert.False(t, result)
 	assert.Equal(t, "", command)
 }
+
+func TestLookupEnvOrString_Default(t *testing.T) {
+	args := []string{"./rpc", ""}
+	flags := NewFlags(args)
+	result := flags.lookupEnvOrString("URL", "")
+	assert.Equal(t, "", result)
+}
+func TestLookupEnvOrString_Env(t *testing.T) {
+	args := []string{"./rpc", ""}
+	os.Setenv("URL", "wss://localhost")
+	flags := NewFlags(args)
+	result := flags.lookupEnvOrString("URL", "")
+	assert.Equal(t, "wss://localhost", result)
+}
+
+func TestLookupEnvOrBool_Default(t *testing.T) {
+	args := []string{"./rpc", ""}
+	flags := NewFlags(args)
+	result := flags.lookupEnvOrBool("SKIP_CERT_CHECK", false)
+	assert.Equal(t, false, result)
+}
+func TestLookupEnvOrBool_Env(t *testing.T) {
+	args := []string{"./rpc", ""}
+	os.Setenv("SKIP_CERT_CHECK", "true")
+	flags := NewFlags(args)
+	result := flags.lookupEnvOrBool("SKIP_CERT_CHECK", false)
+	assert.Equal(t, true, result)
+}
+
+func TestLookupEnvOrBool_EnvError(t *testing.T) {
+	args := []string{"./rpc", ""}
+	os.Setenv("SKIP_CERT_CHECK", "notparsable")
+	flags := NewFlags(args)
+	result := flags.lookupEnvOrBool("SKIP_CERT_CHECK", false)
+	assert.Equal(t, false, result)
+}


### PR DESCRIPTION
URL - url of server (-u)
PROXY - if using a proxy server (-p)
SKIP_CERT_CHECK - skip cert checking (-n)
PROFILE - profile to use for activation (-profile)
DNS_SUFFIX - used for dns suffix override (-d)
HOSTNAME - override hostname (-h)
AMT_PASSWORD - AMT password (-password)