### PR TITLE
feat(output): enable json output for amtinfo

### DIFF
--- a/internal/rpc/flags_test.go
+++ b/internal/rpc/flags_test.go
@@ -185,6 +185,16 @@ func TestParseFlagsAMTInfo(t *testing.T) {
 	command, result := flags.ParseFlags()
 	assert.False(t, result)
 	assert.Equal(t, "amtinfo", command)
+	assert.Equal(t, false, flags.JsonOutput)
+}
+
+func TestParseFlagsAMTInfoJSON(t *testing.T) {
+	args := []string{"./rpc", "amtinfo", "-json"}
+	flags := NewFlags(args)
+	command, result := flags.ParseFlags()
+	assert.False(t, result)
+	assert.Equal(t, "amtinfo", command)
+	assert.Equal(t, true, flags.JsonOutput)
 }
 func TestParseFlagsActivate(t *testing.T) {
 	args := []string{"./rpc", "activate"}


### PR DESCRIPTION
for #22 

```
sudo ./rpc amtinfo -json 
{
  "AMT": "15.0.30",
  "Build Number": "1776",
  "Control Mode": "pre-provisioning state",
  "DNS Suffix": "",
  "DNS Suffix (OS)": "",
  "Hostname (OS)": "p1",
  "RAS": {
    "NetworkStatus": "unknown",
    "RemoteStatus": "not connected",
    "RemoteTrigger": "user initiated",
    "MPSHostname": ""
  },
  "SKU": "16392",
  "UUID": "a94a55cc-267e-11b2-a85c-e2a9c1f3470e",
  "Wired Adapter": {
    "IsEnabled": true,
    "LinkStatus": "down",
    "DHCPEnabled": true,
    "DHCPMode": "active",
    "IPAddress": "0.0.0.0",
    "MACAddress": "00:00:00:00:00:00"
  },
  "Wireless Adapter": {
    "IsEnabled": false,
    "LinkStatus": "down",
    "DHCPEnabled": true,
    "DHCPMode": "passive",
    "IPAddress": "0.0.0.0",
    "MACAddress": "00:00:00:00:00:00"
  }
}
```