### PR TITLE
add the -json flag definition to activate, deactivate and maintainence commands

### DIFF
--- a/internal/rpc/flags.go
+++ b/internal/rpc/flags.go
@@ -44,8 +44,11 @@ func NewFlags(args []string) *Flags {
 	flags.amtInfoCommand.BoolVar(&flags.JsonOutput, "json", false, "json output")
 
 	flags.amtActivateCommand = flag.NewFlagSet("activate", flag.ExitOnError)
+	flags.amtActivateCommand.BoolVar(&flags.JsonOutput, "json", false, "json output")
 	flags.amtDeactivateCommand = flag.NewFlagSet("deactivate", flag.ExitOnError)
+	flags.amtDeactivateCommand.BoolVar(&flags.JsonOutput, "json", false, "json output")
 	flags.amtMaintenanceCommand = flag.NewFlagSet("maintenance", flag.ExitOnError)
+	flags.amtMaintenanceCommand.BoolVar(&flags.JsonOutput, "json", false, "json output")
 	flags.setupCommonFlags()
 	return flags
 }


### PR DESCRIPTION
Heya @Craig-Spencer-12  - I started riffing, and this will be "interesting"

```
sven@p1:~/src/open-amt-cloud-toolkit/rpc-go$ sudo ./rpc activate -json -u wss://10.13.13.193/activate -profile profileAMTDefault
{"level":"info","msg":"no connection to close","time":"2021-12-02T16:15:40+10:00"}
Starting MicroLMS.
{"level":"info","msg":"connecting to wss://10.13.13.193/activate","time":"2021-12-02T16:15:45+10:00"}
{"level":"error","msg":"error connecting to RPS","time":"2021-12-02T16:15:45+10:00"}
{"level":"error","msg":"x509: cannot validate certificate for 10.13.13.193 because it doesn't contain any IP SANs","time":"2021-12-02T16:15:45+10:00"}
```

"Starting MicroLMS." comes from the c code?


