### PR TITLE
fix: remove extra log.error statement

### DIFF
--- a/internal/rps/rps.go
+++ b/internal/rps/rps.go
@@ -133,7 +133,6 @@ func (amt *AMTActivationServer) ProcessMessage(message []byte) []byte {
 		if err == nil {
 			log.Error(statusMessage.Status)
 		} else {
-			log.Error(err)
 			log.Error(activation.Message)
 		}
 		return nil


### PR DESCRIPTION
Removes log of 'invalid character...' error message
![image](https://user-images.githubusercontent.com/22204562/199852035-50948d68-72f3-4d7e-8b42-3532485ff6d5.png)
