### PR TITLE
fix(internal): GetOSDnsSuffixOS bug with docker desktop

### DIFF
--- a/internal/amt/commands.go
+++ b/internal/amt/commands.go
@@ -7,8 +7,6 @@ package amt
 import (
 	"errors"
 	"fmt"
-	"net"
-	"os"
 	"rpc/pkg/pthi"
 	"rpc/pkg/utils"
 	"strconv"
@@ -212,33 +210,6 @@ func (amt AMTCommand) Unprovision() (int, error) {
 	}
 
 	return result, nil
-}
-
-// GetDNSSuffix ...
-func (amt AMTCommand) GetOSDNSSuffix() (string, error) {
-	lanResult, _ := amt.GetLANInterfaceSettings(false)
-	ifaces, _ := net.Interfaces()
-	for _, v := range ifaces {
-		if v.HardwareAddr.String() == lanResult.MACAddress {
-			addrs, _ := v.Addrs()
-			for _, a := range addrs {
-				networkIp, ok := a.(*net.IPNet)
-				if ok && !networkIp.IP.IsLoopback() && networkIp.IP.To4() != nil {
-					ip := networkIp.IP.String()
-					suffix, _ := net.LookupAddr(ip)
-					if len(suffix) > 0 {
-						hostname, _ := os.Hostname()
-						dnsSuffix := strings.Trim(suffix[0], hostname)
-						dnsSuffix = strings.TrimLeft(dnsSuffix, ".")
-						dnsSuffix = strings.TrimRight(dnsSuffix, ".")
-						return dnsSuffix, nil
-					}
-					return "", nil
-				}
-			}
-		}
-	}
-	return "", nil
 }
 
 func (amt AMTCommand) GetDNSSuffix() (string, error) {

--- a/internal/amt/linux.go
+++ b/internal/amt/linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+// +build linux
+
+package amt
+
+import (
+	"os"
+	"strings"
+)
+
+func (amt AMTCommand) GetOSDNSSuffix() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	splitName := strings.SplitAfterN(hostname, ".", 2)
+	if len(splitName) == 2 {
+		return splitName[1], nil
+	}
+	return hostname, err
+}

--- a/internal/amt/windows.go
+++ b/internal/amt/windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+// +build windows
+
+package amt
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func (amt AMTCommand) GetOSDNSSuffix() (string, error) {
+	lanResult, _ := amt.GetLANInterfaceSettings(false)
+
+	var primarySuffix = ""
+	var b []byte
+	l := uint32(15000) // recommended initial size
+	for {
+		b = make([]byte, l)
+		err := windows.GetAdaptersAddresses(syscall.AF_UNSPEC, windows.GAA_FLAG_INCLUDE_PREFIX, 0, (*windows.IpAdapterAddresses)(unsafe.Pointer(&b[0])), &l)
+		if err == nil {
+			if l == 0 {
+				return primarySuffix, nil
+			}
+			break
+		}
+		if err.(syscall.Errno) != syscall.ERROR_BUFFER_OVERFLOW {
+			return primarySuffix, os.NewSyscallError("getadaptersaddresses", err)
+		}
+		if l <= uint32(len(b)) {
+			return primarySuffix, os.NewSyscallError("getadaptersaddresses", err)
+		}
+	}
+	for aa := (*windows.IpAdapterAddresses)(unsafe.Pointer(&b[0])); aa != nil; aa = aa.Next {
+		if aa.PhysicalAddressLength <= 0 {
+			continue
+		}
+		var curMacAddr = make(net.HardwareAddr, aa.PhysicalAddressLength)
+		copy(curMacAddr, aa.PhysicalAddress[:])
+		if curMacAddr.String() == lanResult.MACAddress {
+			primarySuffix = windows.UTF16PtrToString(aa.DnsSuffix)
+			break
+		}
+	}
+	return primarySuffix, nil
+}


### PR DESCRIPTION
created OS specific methods to use more precise system calls rather than dns resolve of the IP address.