### PR TITLE
ci: only release when semantic-release generates a new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,20 +42,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # the .nextVersion file will be created by semantic-release
       - name: Get Next Version
         id: version
         run: |
-          git fetch --tags
-          echo "next=$(git tag | sort -r --version-sort | head -n1)" >> "$GITHUB_OUTPUT"
+          if [ -f .nextVersion ]; then
+            echo "next=$(cat .nextVersion)" >> "$GITHUB_OUTPUT"
+          else
+            echo "next=none" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        if: ${{ steps.version.outputs.next != 'none' }}
         with:
           repository: open-amt-cloud-toolkit/e2e-testing
           ref: docker-release
           clean: true
-          token: ${{ secrets.PROJECTS_PAT }}
+          token: ${{ secrets.DOCKER_RELEASE_PAT }}
 
       - name: Create docker-release @ ${{ steps.version.outputs.next }}
+        if: ${{ steps.version.outputs.next != 'none' }}
         env:
           RELEASE_YAML: release/rpc-go.yml
           NEXT_VERSION: ${{ steps.version.outputs.next }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 **/*.dll
 **/*.h
 **/launch.json
+.nextVersion

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,7 +11,8 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "docker build -t vprodemo.azurecr.io/rpc-go:v${nextRelease.version} .",
-        "publishCmd": "docker push vprodemo.azurecr.io/rpc-go:v${nextRelease.version}"
+        "publishCmd": "docker push vprodemo.azurecr.io/rpc-go:v${nextRelease.version}",
+        "verifyReleaseCmd": "echo v${nextRelease.version} > .nextVersion"
       }
     ]
   ]


### PR DESCRIPTION
Modify release workflow to only publish a new release to `e2e-testing@docker-release` when a new version number is generated by semantic-release.