### PR TITLE
feat: support smb: urls for remote .yaml or .pfx config files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.20
 // replace github.com/open-amt-cloud-toolkit/go-wsman-messages => ../go-wsman-messages
 
 require (
+	github.com/hirochachacha/go-smb2 v1.1.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/ilyakaznacheev/cleanenv v1.5.0
 	github.com/open-amt-cloud-toolkit/go-wsman-messages v1.8.4
@@ -15,6 +16,7 @@ require (
 )
 
 require (
+	github.com/geoffgarside/ber v1.1.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=
+github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
+github.com/hirochachacha/go-smb2 v1.1.0 h1:b6hs9qKIql9eVXAiN0M2wSFY5xnhbHAQoCwRKbaRTZI=
+github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4FtcxjBfsY8TZE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/ilyakaznacheev/cleanenv v1.5.0 h1:0VNZXggJE2OYdXE87bfSSwGxeiGt9moSR2lOrsHHvr4=

--- a/internal/flags/activate.go
+++ b/internal/flags/activate.go
@@ -23,7 +23,7 @@ func (f *Flags) handleActivateCommand() utils.ReturnCode {
 		return nil
 	})
 	// for local activation in ACM mode need a few more items
-	f.amtActivateCommand.StringVar(&f.configContent, "config", "", "specify a config file ")
+	f.amtActivateCommand.StringVar(&f.configContent, "config", "", "specify a config file or smb: file share URL")
 	f.amtActivateCommand.StringVar(&f.LocalConfig.ACMSettings.AMTPassword, "amtPassword", f.lookupEnvOrString("AMT_PASSWORD", ""), "amt password")
 	f.amtActivateCommand.StringVar(&f.LocalConfig.ACMSettings.ProvisioningCert, "provisioningCert", f.lookupEnvOrString("PROVISIONING_CERT", ""), "provisioning certificate")
 	f.amtActivateCommand.StringVar(&f.LocalConfig.ACMSettings.ProvisioningCertPwd, "provisioningCertPwd", f.lookupEnvOrString("PROVISIONING_CERT_PASSWORD", ""), "provisioning certificate password")

--- a/internal/flags/configure.go
+++ b/internal/flags/configure.go
@@ -104,7 +104,7 @@ func (f *Flags) handleAddWifiSettings() utils.ReturnCode {
 	f.flagSetAddWifiSettings.StringVar(&f.LogLevel, "l", "info", "Log level (panic,fatal,error,warn,info,debug,trace)")
 	f.flagSetAddWifiSettings.BoolVar(&f.JsonOutput, "json", false, "JSON output")
 	f.flagSetAddWifiSettings.StringVar(&f.Password, "password", f.lookupEnvOrString("AMT_PASSWORD", ""), "AMT password")
-	f.flagSetAddWifiSettings.StringVar(&f.configContent, "config", "", "specify a config file ")
+	f.flagSetAddWifiSettings.StringVar(&f.configContent, "config", "", "specify a config file or smb: file share URL")
 	f.flagSetAddWifiSettings.StringVar(&configJson, "configJson", "", "configuration as a JSON string")
 	f.flagSetAddWifiSettings.StringVar(&secretsFilePath, "secrets", "", "specify a secrets file ")
 	// Params for entering a single wifi config from command line

--- a/internal/smb/samba.go
+++ b/internal/smb/samba.go
@@ -1,0 +1,148 @@
+package smb
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hirochachacha/go-smb2"
+	log "github.com/sirupsen/logrus"
+	"net"
+	"net/url"
+	"os"
+	"os/user"
+	"strings"
+)
+
+type Service struct {
+	Url          string
+	Host         string
+	Port         string
+	User         string
+	Password     string
+	Domain       string
+	ShareName    string
+	FilePath     string
+	FileContents []byte
+}
+
+func NewSambaService(url string) Service {
+	return Service{
+		Url: url,
+	}
+}
+
+func (s *Service) Fetch() error {
+	if err := s.ParseUrl(); err != nil {
+		return err
+	}
+	return s.FetchFile()
+}
+
+func (s *Service) FetchFile() error {
+
+	pwdOutput := "***"
+	if s.Password == "" {
+		pwdOutput = "none"
+	}
+	// by usage, this method is called before log leve is set
+	// so Debugf statement here is not effective
+	log.Infof("fetching remote file server: %s:%s, user: %s, pwd: %s, domain: %s, share: %s, path: %s",
+		s.Host, s.Port, s.User, pwdOutput, s.Domain, s.ShareName, s.FilePath)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", s.Host, s.Port))
+	if err != nil {
+		return err
+	}
+	defer func(conn net.Conn) {
+		err = conn.Close()
+	}(conn)
+
+	dialer := &smb2.Dialer{
+		Initiator: &smb2.NTLMInitiator{
+			User:     s.User,
+			Password: s.Password,
+			Domain:   s.Domain,
+		},
+	}
+
+	session, err := dialer.Dial(conn)
+	if err != nil {
+		return err
+	}
+	defer func(session *smb2.Session) {
+		err = session.Logoff()
+	}(session)
+
+	fs, err := session.Mount(s.ShareName)
+	if err != nil {
+		return err
+	}
+	defer func(fs *smb2.Share) {
+		err = fs.Umount()
+	}(fs)
+
+	s.FileContents, err = fs.ReadFile(s.FilePath)
+	return err
+}
+
+// ParseUrl - parses according to https://www.iana.org/assignments/uri-schemes/prov/smb
+// except for the query string
+// smb://[[<domain>;]<username>[:<password>]@]<server>[:<port>][/[<share>[/[<path>]]][?[<param>=<value>[;<param2>=<value2>[...]]]]]
+func (s *Service) ParseUrl() error {
+	u, err := url.Parse(s.Url)
+	if err != nil {
+		return err
+	}
+
+	if u.Scheme != "smb" {
+		return errors.New("invalid scheme")
+	}
+	s.Host = u.Hostname()
+	if s.Host == "" {
+		return errors.New("missing hostname")
+	}
+	s.Port = u.Port()
+	if s.Port == "" {
+		s.Port = "445"
+	}
+
+	splits := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(splits) < 2 {
+		return errors.New("invalid path spec, expecting shareName and filePath to be included: " + u.Path)
+	}
+
+	s.ShareName = splits[0]
+	s.FilePath = strings.Join(splits[1:], "/")
+
+	// smb url spec allows for domain in front of user with a semicolon
+	splits = strings.Split(u.User.Username(), ";")
+	if len(splits) == 1 {
+		s.User = splits[0]
+	} else if len(splits) == 2 {
+		s.Domain = splits[0]
+		s.User = splits[1]
+	}
+
+	if s.User == "" {
+		curUser, err := user.Current()
+		if err != nil {
+			return err
+		}
+		s.User = curUser.Username
+	}
+	if s.User == "root" {
+		if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+			s.User = sudoUser
+		}
+	}
+
+	s.Password, _ = u.User.Password()
+	if s.Password == "*" {
+		fmt.Println("Please enter smb password: ")
+		_, err := fmt.Scanln(&s.Password)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/smb/samba_test.go
+++ b/internal/smb/samba_test.go
@@ -1,0 +1,48 @@
+package smb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os/user"
+	"testing"
+)
+
+func TestService_ParseUrl(t *testing.T) {
+
+	t.Run("expect happy path", func(t *testing.T) {
+		svc := NewSambaService("smb://some.test.server/sharename/and/a/file/path.txt")
+		err := svc.ParseUrl()
+		assert.Nil(t, err)
+		curUser, err := user.Current()
+		assert.Nil(t, err)
+		assert.Equal(t, "some.test.server", svc.Host)
+		assert.Equal(t, "445", svc.Port)
+		assert.Equal(t, "sharename", svc.ShareName)
+		assert.Equal(t, "and/a/file/path.txt", svc.FilePath)
+		assert.Equal(t, curUser.Username, svc.User)
+		assert.Equal(t, "", svc.Password)
+		assert.Equal(t, "", svc.Domain)
+	})
+
+	t.Run("expect happy path with username, and password", func(t *testing.T) {
+		svc := NewSambaService("smb://test-user:test-pwd@some.test.server/sharename/and/a/file/path.txt")
+		err := svc.ParseUrl()
+		assert.Nil(t, err)
+		assert.Equal(t, "some.test.server", svc.Host)
+		assert.Equal(t, "445", svc.Port)
+		assert.Equal(t, "sharename", svc.ShareName)
+		assert.Equal(t, "and/a/file/path.txt", svc.FilePath)
+		assert.Equal(t, "test-user", svc.User)
+		assert.Equal(t, "test-pwd", svc.Password)
+		assert.Equal(t, "", svc.Domain)
+	})
+
+	t.Run("expect happy path with domain, username, and no password", func(t *testing.T) {
+		svc := NewSambaService("smb://test-domain;test-user@some.test.server/sharename/and/a/file/path.txt")
+		err := svc.ParseUrl()
+		assert.Nil(t, err)
+		assert.Equal(t, "some.test.server", svc.Host)
+		assert.Equal(t, "test-user", svc.User)
+		assert.Equal(t, "", svc.Password)
+		assert.Equal(t, "test-domain", svc.Domain)
+	})
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -10,7 +10,7 @@ const (
 	// ProjectName is the name of the executable
 	ProjectName = "rpc"
 	// ProjectVersion is the full version of this executable
-	ProjectVersion  = "2.19.0"
+	ProjectVersion  = "2.21.0"
 	ProtocolVersion = "4.0.0"
 	// ClientName is the name of the exectable
 	ClientName = "RPC"


### PR DESCRIPTION
`  smb://[[<domain>;]<username>[:<password>]@]<server>[:<port>][/[<share>[/[<path>]]]`
  default username is current user id
  prompts user to enter password if asterisk is used for password field
  default port 445