### PR TITLE
feat: prompts for password in local commands activate and configure mebx

### DIFF
--- a/internal/flags/activate.go
+++ b/internal/flags/activate.go
@@ -78,11 +78,20 @@ func (f *Flags) handleActivateCommand() error {
 			return utils.InvalidParameterCombination
 		}
 
+		if f.LocalConfig.ACMSettings.AMTPassword == "" && f.Password == "" {
+			if rc := f.ReadNewPasswordTo(&f.Password, "New AMT Password"); rc != nil {
+				return rc
+			}
+			f.LocalConfig.ACMSettings.AMTPassword = f.Password
+			f.LocalConfig.Password = f.Password
+		}
+
 		if f.UseACM {
 			err := f.handleLocalConfig()
 			if err != nil {
 				return utils.FailedReadingConfiguration
 			}
+
 			// Check if all fields are filled
 			v := reflect.ValueOf(f.LocalConfig.ACMSettings)
 			for i := 0; i < v.NumField(); i++ {
@@ -93,14 +102,6 @@ func (f *Flags) handleActivateCommand() error {
 			}
 
 		}
-
-		// Only for CCM it asks for password.
-		if !f.UseACM && f.Password == "" {
-			if rc := f.ReadPasswordFromUser(); rc != nil {
-				return utils.MissingOrIncorrectPassword
-			}
-		}
-		f.LocalConfig.Password = f.Password
 
 		if f.UUID != "" {
 			fmt.Println("-uuid cannot be use in local activation")

--- a/internal/flags/configure.go
+++ b/internal/flags/configure.go
@@ -151,21 +151,31 @@ func (f *Flags) handleSyncClock() error {
 }
 
 func (f *Flags) handleMEBxPassword() error {
-	var err error
-	if len(f.commandLineArgs) == 3 {
-		f.printConfigurationUsage()
-		return utils.IncorrectCommandLineParameters
-	}
 	f.flagSetMEBx.BoolVar(&f.Verbose, "v", false, "Verbose output")
 	f.flagSetMEBx.StringVar(&f.LogLevel, "l", "info", "Log level (panic,fatal,error,warn,info,debug,trace)")
 	f.flagSetMEBx.BoolVar(&f.JsonOutput, "json", false, "JSON output")
 	f.flagSetMEBx.StringVar(&f.Password, "password", f.lookupEnvOrString("AMT_PASSWORD", ""), "AMT password")
 	f.flagSetMEBx.StringVar(&f.MEBxPassword, "mebxpassword", f.lookupEnvOrString("MEBX_PASSWORD", ""), "MEBX password")
 
-	if err = f.flagSetMEBx.Parse(f.commandLineArgs[3:]); err != nil {
-		f.printConfigurationUsage()
-		return utils.IncorrectCommandLineParameters
+	if len(f.commandLineArgs) > 3 {
+		if err := f.flagSetMEBx.Parse(f.commandLineArgs[3:]); err != nil {
+			f.printConfigurationUsage()
+			return utils.IncorrectCommandLineParameters
+		}
 	}
+
+	if f.Password == "" {
+		if rc := f.ReadPasswordFromUser(); rc != nil {
+			return rc
+		}
+	}
+
+	if f.MEBxPassword == "" {
+		if rc := f.ReadNewPasswordTo(&f.MEBxPassword, "New MEBx Password"); rc != nil {
+			return rc
+		}
+	}
+
 	return nil
 }
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -249,6 +249,26 @@ func (f *Flags) PromptUserInput(prompt string, value *string) error {
 	return nil
 }
 
+func (f *Flags) ReadNewPasswordTo(saveLocation *string, promptPhrase string) error {
+	var password, confirmPassword string
+	var err error
+
+	fmt.Printf("Please enter %s: \n", promptPhrase)
+	password, err = f.passwordReader.ReadPassword()
+	if password == "" || err != nil {
+		return utils.MissingOrIncorrectPassword
+	}
+
+	fmt.Printf("Please confirm %s: \n", promptPhrase)
+	confirmPassword, err = f.passwordReader.ReadPassword()
+	if password != confirmPassword || err != nil {
+		return utils.PasswordsDoNotMatch
+	}
+
+	*saveLocation = password
+	return nil
+}
+
 func (f *Flags) ReadPasswordFromUser() error {
 	fmt.Println("Please enter AMT Password: ")
 	var password string

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -470,3 +470,11 @@ func TestHandleLocalConfig(t *testing.T) {
 		assert.Equal(t, utils.FailedReadingConfiguration, err)
 	})
 }
+
+func TestReadNewPasswordTo(t *testing.T) {
+	args := []string{"./rpc"}
+	flags := NewFlags(args, MockPRSuccess)
+	var password string
+	flags.ReadNewPasswordTo(&password, "TEST")
+	assert.Equal(t, utils.TestPassword, password)
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -71,9 +71,9 @@ var MissingOrIncorrectSecondaryDNS = CustomError{Code: 32, Message: "MissingOrIn
 var InvalidParameterCombination = CustomError{Code: 33, Message: "InvalidParameterCombination"}
 var FailedReadingConfiguration = CustomError{Code: 34, Message: "FailedReadingConfiguration"}
 var MissingOrInvalidConfiguration = CustomError{Code: 35, Message: "MissingOrInvalidConfiguration"}
-
 var InvalidUserInput = CustomError{Code: 36, Message: "InvalidUserInput"}
 var InvalidUUID = CustomError{Code: 37, Message: "InvalidUUID"}
+var PasswordsDoNotMatch = CustomError{Code: 38, Message: "PasswordsDoNotMatch"}
 
 // (70-99) Connection Errors
 var RPSAuthenticationFailed = CustomError{Code: 70, Message: "RPSAuthenticationFailed"}


### PR DESCRIPTION
* Created password confirmation function for new password input
* Prompts for New AMT Password when one is not provided in Local ACM Activation
* Prompts for New MEBx Password when one is not provided
* Prompts for AMT Password when one is not provided to `rpc configure mebx`

### Review should test
`sudo ./rpc activate -local -acm -provisioningCert “[CERT]” -provisioningCertPwd P@ssw0rd`
* should prompt for the new password then prompt for confirmation
* should fail when the passwords do not match
 
`sudo ./rpc configure mebx`
* should prompt for AMT Password then prompt for new MEBx password then prompt to confirm new MEBx Password
* should fail when new MEBx password does not match confirmation
* should only prompt for missing flags. If -password is there it will not prompt for AMT Password and if -mebxpassword is there it will not prompt for MEBx password. All combinations of flags should work
