### PR TITLE
feat: adds addwiredsettings local configure command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,9 @@ acmactivate:
   amtPassword: 'test'
   provisioningCert: 'your provisioning certificate'
   provisioningCertPwd: 'test'
+wiredConfig:
+  dhcp: true
+  ipsync: true
 wifiConfigs:
   - profileName: 'exampleWifiWPA2' # friendly name, alphanumeric only
     ssid: 'exampleSSID'

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -3,6 +3,7 @@ package config
 type (
 	Config struct {
 		Password         string            `yaml:"password"`
+		EthernetConfigs  EthernetConfig    `yaml:"wiredConfig"`
 		WifiConfigs      []WifiConfig      `yaml:"wifiConfigs"`
 		Ieee8021xConfigs []Ieee8021xConfig `yaml:"ieee8021xConfigs"`
 		ACMSettings      ACMSettings       `yaml:"acmactivate"`
@@ -15,6 +16,16 @@ type (
 		EncryptionMethod     int    `yaml:"encryptionMethod"`
 		PskPassphrase        string `yaml:"pskPassphrase"`
 		Ieee8021xProfileName string `yaml:"ieee8021xProfileName"`
+	}
+	EthernetConfig struct {
+		DHCPEnabled  bool   `yaml:"dhcp"`
+		Static       bool   `yaml:"static"`
+		IpSync       bool   `yaml:"ipsync"`
+		IpAddress    string `yaml:"ipaddress"`
+		Subnetmask   string `yaml:"subnetmask"`
+		Gateway      string `yaml:"gateway"`
+		PrimaryDNS   string `yaml:"primarydns"`
+		SecondaryDNS string `yaml:"secondarydns"`
 	}
 	SecretConfig struct {
 		Secrets []Secret `yaml:"secrets"`

--- a/internal/flags/configure.go
+++ b/internal/flags/configure.go
@@ -77,6 +77,8 @@ func (f *Flags) printConfigurationUsage() string {
 	usage := "\nRemote Provisioning Client (RPC) - used for activation, deactivation, maintenance and status of AMT\n\n"
 	usage += "Usage: " + baseCommand + " COMMAND [OPTIONS]\n\n"
 	usage += "Supported Configuration Commands:\n"
+	usage += "  " + utils.SubCommandAddEthernetSettings + " Add or modify ethernet settings in AMT. AMT password is required. A config.yml or command line flags must be provided for all settings. This command runs without cloud interaction.\n"
+	usage += "                  Example: " + baseCommand + " " + utils.SubCommandAddEthernetSettings + " -password YourAMTPassword -config ethernetconfig.yaml\n"
 	usage += "  " + utils.SubCommandAddWifiSettings + " Add or modify WiFi settings in AMT. AMT password is required. A config.yml or command line flags must be provided for all settings. This command runs without cloud interaction.\n"
 	usage += "                  Example: " + baseCommand + " " + utils.SubCommandAddWifiSettings + " -password YourAMTPassword -config wificonfig.yaml\n"
 	usage += "  " + utils.SubCommandEnableWifiPort + "  Enables WiFi port and local profile synchronization settings in AMT. AMT password is required.\n"
@@ -102,6 +104,8 @@ func (f *Flags) handleConfigureCommand() error {
 
 	f.SubCommand = f.commandLineArgs[2]
 	switch f.SubCommand {
+	case utils.SubCommandAddEthernetSettings:
+		err = f.handleAddEthernetSettings()
 	case utils.SubCommandAddWifiSettings:
 		err = f.handleAddWifiSettings()
 	case utils.SubCommandEnableWifiPort:
@@ -234,6 +238,103 @@ func (f *Flags) handleConfigureTLS() error {
 		fs.Usage()
 		return utils.IncorrectCommandLineParameters
 	}
+	return nil
+}
+
+func (f *Flags) handleAddEthernetSettings() error {
+	var configJson string
+	fs := f.NewConfigureFlagSet(utils.SubCommandAddEthernetSettings)
+	fs.StringVar(&f.configContent, "config", "", "Specify a config file or smb: file share URL")
+	fs.StringVar(&configJson, "configJson", "", "Configuration as a JSON string")
+	fs.BoolVar(&f.IpConfiguration.DHCP, "dhcp", false, "Configures wired settings to use dhcp")
+	fs.BoolVar(&f.IpConfiguration.Static, "static", false, "Configures wired settings to use static ip address")
+	fs.BoolVar(&f.IpConfiguration.IpSync, "ipsync", false, "Sync the IP configuration of the host OS to AMT Network Settings")
+	fs.Func(
+		"ipaddress",
+		"IP address to be assigned to AMT",
+		validateIP(&f.IpConfiguration.IpAddress))
+	fs.Func(
+		"subnetmask",
+		"Subnetwork mask to be assigned to AMT",
+		validateIP(&f.IpConfiguration.Netmask))
+	fs.Func("gateway", "Gateway address to be assigned to AMT", validateIP(&f.IpConfiguration.Gateway))
+	fs.Func("primarydns", "Primary DNS to be assigned to AMT", validateIP(&f.IpConfiguration.PrimaryDns))
+	fs.Func("secondarydns", "Secondary DNS to be assigned to AMT", validateIP(&f.IpConfiguration.SecondaryDns))
+
+	if err := fs.Parse(f.commandLineArgs[3:]); err != nil {
+		f.printConfigurationUsage()
+		return utils.IncorrectCommandLineParameters
+	}
+
+	if f.configContent != "" || configJson != "" {
+		err := f.handleLocalConfig()
+		if err != nil {
+			return utils.FailedReadingConfiguration
+		}
+		if configJson != "" {
+			err := json.Unmarshal([]byte(configJson), &f.LocalConfig)
+			if err != nil {
+				log.Error(err)
+				return utils.IncorrectCommandLineParameters
+			}
+		}
+
+		if f.IpConfiguration.DHCP ||
+			f.IpConfiguration.Static ||
+			f.IpConfiguration.IpSync ||
+			f.IpConfiguration.IpAddress != "" ||
+			f.IpConfiguration.Netmask != "" ||
+			f.IpConfiguration.Gateway != "" ||
+			f.IpConfiguration.PrimaryDns != "" ||
+			f.IpConfiguration.SecondaryDns != "" {
+			return utils.IncorrectCommandLineParameters
+		}
+
+		f.IpConfiguration.DHCP = f.LocalConfig.EthernetConfigs.DHCPEnabled
+		f.IpConfiguration.Static = f.LocalConfig.EthernetConfigs.Static
+		f.IpConfiguration.IpSync = f.LocalConfig.EthernetConfigs.IpSync
+		f.IpConfiguration.IpAddress = f.LocalConfig.EthernetConfigs.IpAddress
+		f.IpConfiguration.Netmask = f.LocalConfig.EthernetConfigs.Subnetmask
+		f.IpConfiguration.Gateway = f.LocalConfig.EthernetConfigs.Gateway
+		f.IpConfiguration.PrimaryDns = f.LocalConfig.EthernetConfigs.PrimaryDNS
+		f.IpConfiguration.SecondaryDns = f.LocalConfig.EthernetConfigs.SecondaryDNS
+
+	}
+
+	if f.IpConfiguration.DHCP == f.IpConfiguration.Static {
+		log.Error("must specify -dhcp or -static, but not both")
+		return utils.InvalidParameterCombination
+	}
+
+	if f.IpConfiguration.DHCP && !f.IpConfiguration.IpSync {
+		return utils.InvalidParameterCombination
+	}
+
+	if f.IpConfiguration.IpSync {
+		if f.IpConfiguration.IpAddress != "" ||
+			f.IpConfiguration.Netmask != "" ||
+			f.IpConfiguration.Gateway != "" ||
+			f.IpConfiguration.PrimaryDns != "" ||
+			f.IpConfiguration.SecondaryDns != "" {
+			return utils.InvalidParameterCombination
+		}
+	}
+
+	if f.IpConfiguration.Static && !f.IpConfiguration.IpSync {
+		if f.IpConfiguration.IpAddress == "" {
+			return utils.MissingOrIncorrectStaticIP
+		}
+		if f.IpConfiguration.Netmask == "" {
+			return utils.MissingOrIncorrectNetworkMask
+		}
+		if f.IpConfiguration.Gateway == "" {
+			return utils.MissingOrIncorrectGateway
+		}
+		if f.IpConfiguration.PrimaryDns == "" {
+			return utils.MissingOrIncorrectPrimaryDNS
+		}
+	}
+
 	return nil
 }
 

--- a/internal/flags/configure_test.go
+++ b/internal/flags/configure_test.go
@@ -629,3 +629,48 @@ func TestInvalidAuthenticationProtocols(t *testing.T) {
 			})
 	}
 }
+
+func TestHandleAddEthernetSettings(t *testing.T) {
+	cases := []struct {
+		description    string
+		cmdLine        string
+		expectedResult error
+	}{
+		{description: "fail - dchp without ipsync",
+			cmdLine:        "rpc configure wiredsettings -dhcp -password Passw0rd!",
+			expectedResult: utils.InvalidParameterCombination,
+		},
+		{description: "fail - no flags",
+			cmdLine:        "rpc configure wiredsettings -password Passw0rd!",
+			expectedResult: utils.InvalidParameterCombination,
+		},
+		{description: "fail - static missing subnetmask",
+			cmdLine:        "rpc configure wiredsettings -static -ipaddress 192.168.1.7 -password Passw0rd!",
+			expectedResult: utils.MissingOrIncorrectNetworkMask,
+		},
+		{description: "dhcp and ipsync",
+			cmdLine:        "rpc configure wiredsettings -dhcp -ipsync -password Passw0rd!",
+			expectedResult: nil,
+		},
+		{description: "static and ipsync",
+			cmdLine:        "rpc configure wiredsettings -static -ipsync -password Passw0rd!",
+			expectedResult: nil,
+		},
+		{description: "static and params",
+			cmdLine:        "rpc configure wiredsettings -static -ipaddress 192.168.1.7 -subnetmask 255.255.255.0 -gateway 192.168.1.1 -primarydns 8.8.8.8 -password Passw0rd!",
+			expectedResult: nil,
+		},
+		{description: "config",
+			cmdLine:        "rpc configure wiredsettings -config ../../config.yaml -password Passw0rd!",
+			expectedResult: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			args := strings.Fields(tc.cmdLine)
+			flags := NewFlags(args, MockPRSuccess)
+			gotResult := flags.handleAddEthernetSettings()
+			assert.Equal(t, tc.expectedResult, gotResult)
+		})
+	}
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -33,6 +33,9 @@ type NetEnumerator struct {
 }
 
 type IPConfiguration struct {
+	DHCP         bool   `json:"dhcp"`
+	Static       bool   `json:"static"`
+	IpSync       bool   `json:"ipsync"`
 	IpAddress    string `json:"ipAddress"`
 	Netmask      string `json:"netmask"`
 	Gateway      string `json:"gateway"`
@@ -83,6 +86,7 @@ type Flags struct {
 	amtMaintenanceChangePasswordCommand *flag.FlagSet
 	amtMaintenanceSyncDeviceInfoCommand *flag.FlagSet
 	versionCommand                      *flag.FlagSet
+	flagSetAddEthernetSettings          *flag.FlagSet
 	flagSetAddWifiSettings              *flag.FlagSet
 	flagSetEnableWifiPort               *flag.FlagSet
 	flagSetMEBx                         *flag.FlagSet
@@ -119,6 +123,7 @@ func NewFlags(args []string, pr utils.PasswordReader) *Flags {
 	flags.versionCommand = flag.NewFlagSet(utils.CommandVersion, flag.ContinueOnError)
 	flags.versionCommand.BoolVar(&flags.JsonOutput, "json", false, "json output")
 
+	flags.flagSetAddEthernetSettings = flag.NewFlagSet(utils.SubCommandAddEthernetSettings, flag.ContinueOnError)
 	flags.flagSetAddWifiSettings = flag.NewFlagSet(utils.SubCommandAddWifiSettings, flag.ContinueOnError)
 	flags.flagSetEnableWifiPort = flag.NewFlagSet(utils.SubCommandEnableWifiPort, flag.ContinueOnError)
 	flags.flagSetMEBx = flag.NewFlagSet(utils.SubCommandSetMEBx, flag.ContinueOnError)

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman"
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/general"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
@@ -46,6 +47,9 @@ type WSMANer interface {
 	DeleteWiFiSetting(instanceId string) error
 	EnableWiFi() error
 	AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSettingsRequest, ieee8021xSettings models.IEEE8021xSettings, wifiEndpoint, clientCredential, caCredential string) (wifiportconfiguration.Response, error)
+	// Wired
+	GetEthernetSettings() ([]ethernetport.SettingsResponse, error)
+	PutEthernetSettings(ethernetPortSettings ethernetport.SettingsRequest, instanceId string) (ethernetport.Response, error)
 	// TLS
 	CreateTLSCredentialContext(certHandle string) (response tls.Response, err error)
 	EnumerateTLSSettingData() (response tls.Response, err error)
@@ -153,6 +157,20 @@ func (g *GoWSMANMessages) GetWiFiSettings() ([]wifi.WiFiEndpointSettingsResponse
 		return nil, err
 	}
 	return response.Body.PullResponse.EndpointSettingsItems, nil
+}
+func (g *GoWSMANMessages) GetEthernetSettings() ([]ethernetport.SettingsResponse, error) {
+	response, err := g.wsmanMessages.AMT.EthernetPortSettings.Enumerate()
+	if err != nil {
+		return nil, err
+	}
+	response, err = g.wsmanMessages.AMT.EthernetPortSettings.Pull(response.Body.EnumerateResponse.EnumerationContext)
+	if err != nil {
+		return nil, err
+	}
+	return response.Body.PullResponse.EthernetPortItems, nil
+}
+func (g *GoWSMANMessages) PutEthernetSettings(ethernetPortSettings ethernetport.SettingsRequest, instanceId string) (ethernetport.Response, error) {
+	return g.wsmanMessages.AMT.EthernetPortSettings.Put(ethernetPortSettings, instanceId)
 }
 func (g *GoWSMANMessages) DeletePublicPrivateKeyPair(instanceId string) error {
 	_, err := g.wsmanMessages.AMT.PublicPrivateKeyPair.Delete(instanceId)

--- a/internal/local/configure.go
+++ b/internal/local/configure.go
@@ -12,6 +12,8 @@ import (
 func (service *ProvisioningService) Configure() (err error) {
 	service.interfacedWsmanMessage.SetupWsmanClient("admin", service.flags.Password, logrus.GetLevel() == logrus.TraceLevel)
 	switch service.flags.SubCommand {
+	case utils.SubCommandAddEthernetSettings:
+		return service.AddEthernetSettings()
 	case utils.SubCommandAddWifiSettings:
 		return service.AddWifiSettings()
 	case utils.SubCommandEnableWifiPort:

--- a/internal/local/ethernet.go
+++ b/internal/local/ethernet.go
@@ -1,0 +1,113 @@
+package local
+
+import (
+	"rpc/pkg/utils"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
+	log "github.com/sirupsen/logrus"
+)
+
+func (service *ProvisioningService) AddEthernetSettings() (err error) {
+	err = service.verifyInput()
+	if err != nil {
+		return err
+	}
+
+	getResponse, err := service.interfacedWsmanMessage.GetEthernetSettings()
+	if err != nil {
+		return err
+	}
+
+	settingsRequest, err := service.createEthernetSettingsRequest(getResponse[0])
+	if err != nil {
+		return err
+	}
+
+	_, err = service.interfacedWsmanMessage.PutEthernetSettings(settingsRequest, settingsRequest.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Wired settings configured successfully")
+
+	return nil
+}
+
+func (service *ProvisioningService) verifyInput() error {
+	if service.flags.IpConfiguration.DHCP == service.flags.IpConfiguration.Static || (service.flags.IpConfiguration.DHCP && !service.flags.IpConfiguration.IpSync) {
+		return utils.InvalidParameterCombination
+	}
+
+	if service.flags.IpConfiguration.DHCP {
+		if service.flags.IpConfiguration.IpAddress != "" ||
+			service.flags.IpConfiguration.Netmask != "" ||
+			service.flags.IpConfiguration.Gateway != "" ||
+			service.flags.IpConfiguration.PrimaryDns != "" ||
+			service.flags.IpConfiguration.SecondaryDns != "" {
+			return utils.InvalidParameterCombination
+		}
+	}
+
+	if service.flags.IpConfiguration.Static && !service.flags.IpConfiguration.IpSync {
+		if service.flags.IpConfiguration.IpAddress == "" {
+			return utils.MissingOrIncorrectStaticIP
+		}
+		if service.flags.IpConfiguration.Netmask == "" {
+			return utils.MissingOrIncorrectNetworkMask
+		}
+		if service.flags.IpConfiguration.Gateway == "" {
+			return utils.MissingOrIncorrectGateway
+		}
+		if service.flags.IpConfiguration.PrimaryDns == "" {
+			return utils.MissingOrIncorrectPrimaryDNS
+		}
+	}
+
+	return nil
+}
+
+func (service *ProvisioningService) createEthernetSettingsRequest(getResponse ethernetport.SettingsResponse) (request ethernetport.SettingsRequest, err error) {
+	settingsRequest := ethernetport.SettingsRequest{
+		XMLName:        getResponse.XMLName,
+		H:              "",
+		ElementName:    getResponse.ElementName,
+		InstanceID:     getResponse.InstanceID,
+		SharedMAC:      getResponse.SharedMAC,
+		SharedStaticIp: getResponse.SharedStaticIp,
+		IpSyncEnabled:  getResponse.IpSyncEnabled,
+		DHCPEnabled:    getResponse.DHCPEnabled,
+		IPAddress:      getResponse.IPAddress,
+		SubnetMask:     getResponse.SubnetMask,
+		DefaultGateway: getResponse.DefaultGateway,
+		PrimaryDNS:     getResponse.PrimaryDNS,
+		SecondaryDNS:   getResponse.SecondaryDNS,
+	}
+
+	if service.flags.IpConfiguration.DHCP {
+		settingsRequest.DHCPEnabled = true
+		settingsRequest.IpSyncEnabled = true
+		settingsRequest.SharedStaticIp = false
+	} else {
+		settingsRequest.DHCPEnabled = false
+		settingsRequest.IpSyncEnabled = service.flags.IpConfiguration.IpSync
+		settingsRequest.SharedStaticIp = service.flags.IpConfiguration.IpSync
+	}
+
+	if settingsRequest.IpSyncEnabled {
+		settingsRequest.IPAddress = ""
+		settingsRequest.SubnetMask = ""
+		settingsRequest.DefaultGateway = ""
+		settingsRequest.PrimaryDNS = ""
+		settingsRequest.SecondaryDNS = ""
+	}
+
+	if !service.flags.IpConfiguration.DHCP && !service.flags.IpConfiguration.IpSync {
+		settingsRequest.IPAddress = service.flags.IpConfiguration.IpAddress
+		settingsRequest.SubnetMask = service.flags.IpConfiguration.Netmask
+		settingsRequest.DefaultGateway = service.flags.IpConfiguration.Gateway
+		settingsRequest.PrimaryDNS = service.flags.IpConfiguration.PrimaryDns
+		settingsRequest.SecondaryDNS = service.flags.IpConfiguration.SecondaryDns
+	}
+
+	return settingsRequest, nil
+}

--- a/internal/local/ethernet_test.go
+++ b/internal/local/ethernet_test.go
@@ -1,0 +1,172 @@
+package local
+
+import (
+	"rpc/internal/flags"
+	"rpc/pkg/utils"
+	"testing"
+
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWiredSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       *flags.Flags
+		setupMocks  func(*MockWSMAN)
+		expectedErr error
+	}{
+		{
+			name: "Success - DHCP and IpSync",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					DHCP:   true,
+					IpSync: true,
+				},
+			},
+			setupMocks: func(mock *MockWSMAN) {
+				putEthernetResponse = ethernetport.Response{
+					Body: ethernetport.Body{
+						GetAndPutResponse: ethernetport.SettingsResponse{
+							IpSyncEnabled: true,
+							DHCPEnabled:   true,
+						},
+					},
+				}
+				errPutEthernetSettings = nil
+			},
+		},
+		{
+			name: "Success - Static and IpSync",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					Static: true,
+					IpSync: true,
+				},
+			},
+			setupMocks: func(mock *MockWSMAN) {
+				putEthernetResponse = ethernetport.Response{
+					Body: ethernetport.Body{
+						GetAndPutResponse: ethernetport.SettingsResponse{
+							IpSyncEnabled:  true,
+							SharedStaticIp: true,
+						},
+					},
+				}
+				errPutEthernetSettings = nil
+			},
+		},
+		{
+			name: "Success - Static and Info",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					Static:     true,
+					IpAddress:  "192.168.1.7",
+					Netmask:    "255.255.255.0",
+					Gateway:    "192.168.1.1",
+					PrimaryDns: "8.8.8.8",
+				},
+			},
+			setupMocks: func(mock *MockWSMAN) {
+				putEthernetResponse = ethernetport.Response{
+					Body: ethernetport.Body{
+						GetAndPutResponse: ethernetport.SettingsResponse{
+							SharedStaticIp: true,
+							IPAddress:      "192.168.1.7",
+							SubnetMask:     "255.255.255.0",
+							DefaultGateway: "192.168.1.1",
+							PrimaryDNS:     "8.8.8.8",
+						},
+					},
+				}
+				errPutEthernetSettings = nil
+			},
+		},
+		{
+			name: "Success - Static and Info and secondaryDns",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					Static:       true,
+					IpAddress:    "192.168.1.7",
+					Netmask:      "255.255.255.0",
+					Gateway:      "192.168.1.1",
+					PrimaryDns:   "8.8.8.8",
+					SecondaryDns: "4.4.4.4",
+				},
+			},
+			setupMocks: func(mock *MockWSMAN) {
+				putEthernetResponse = ethernetport.Response{
+					Body: ethernetport.Body{
+						GetAndPutResponse: ethernetport.SettingsResponse{
+							SharedStaticIp: true,
+							IPAddress:      "192.168.1.7",
+							SubnetMask:     "255.255.255.0",
+							DefaultGateway: "192.168.1.1",
+							PrimaryDNS:     "8.8.8.8",
+							SecondaryDNS:   "4.4.4.4",
+						},
+					},
+				}
+				errPutEthernetSettings = nil
+			},
+		},
+		{
+			name: "Fail - No DHCP or Static",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					DHCP:   false,
+					Static: false,
+				},
+			},
+			setupMocks:  func(mock *MockWSMAN) {},
+			expectedErr: utils.InvalidParameterCombination,
+		},
+		{
+			name: "Fail - Static, No IpSync, Missing Info",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					Static: true,
+				},
+			},
+			setupMocks:  func(mock *MockWSMAN) {},
+			expectedErr: utils.MissingOrIncorrectStaticIP,
+		},
+		{
+			name: "Fail - DHCP and Info ",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					DHCP:         true,
+					IpAddress:    "192.168.1.7",
+					SecondaryDns: "4.4.4.4",
+				},
+			},
+			setupMocks:  func(mock *MockWSMAN) {},
+			expectedErr: utils.InvalidParameterCombination,
+		},
+		{
+			name: "Fail - WSManMessage Error",
+			flags: &flags.Flags{
+				IpConfiguration: flags.IPConfiguration{
+					DHCP:   true,
+					IpSync: true,
+				},
+			},
+			setupMocks: func(mock *MockWSMAN) {
+				errPutEthernetSettings = utils.WSMANMessageError
+			},
+			expectedErr: utils.WSMANMessageError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockWsman := new(MockWSMAN)
+			tc.setupMocks(mockWsman)
+
+			testService := NewProvisioningService(tc.flags)
+			testService.interfacedWsmanMessage = mockWsman
+
+			err := testService.AddEthernetSettings()
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/internal/local/lps_test.go
+++ b/internal/local/lps_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/general"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publickey"
 	"github.com/open-amt-cloud-toolkit/go-wsman-messages/v2/pkg/wsman/amt/publicprivate"
@@ -443,6 +444,24 @@ var errAddWiFiSettings error = nil
 
 func (m MockWSMAN) AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSettingsRequest, ieee8021xSettings models.IEEE8021xSettings, wifiEndpoint, clientCredential, caCredential string) (wifiportconfiguration.Response, error) {
 	return wifiportconfiguration.Response{}, errAddWiFiSettings
+}
+
+var errGetEthernetSettings error = nil
+var getEthernetSettingsResponse = []ethernetport.SettingsResponse{{}}
+
+func (m MockWSMAN) GetEthernetSettings() ([]ethernetport.SettingsResponse, error) {
+	return getEthernetSettingsResponse, errGetEthernetSettings
+}
+
+var putEthernetResponse ethernetport.Response = ethernetport.Response{}
+var errPutEthernetSettings error = nil
+
+func (m MockWSMAN) PutEthernetSettings(ethernetport.SettingsRequest, string) (ethernetport.Response, error) {
+	if errPutEthernetSettings != nil {
+		return ethernetport.Response{}, errPutEthernetSettings
+	}
+
+	return putEthernetResponse, nil
 }
 
 // Mock the AMT Hardware

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -31,15 +31,16 @@ const (
 	CommandVersion     = "version"
 	CommandConfigure   = "configure"
 
-	SubCommandAddWifiSettings = "addwifisettings"
-	SubCommandEnableWifiPort  = "enablewifiport"
-	SubCommandSetMEBx         = "mebx"
-	SubCommandConfigureTLS    = "tls"
-	SubCommandChangePassword  = "changepassword"
-	SubCommandSyncDeviceInfo  = "syncdeviceinfo"
-	SubCommandSyncClock       = "syncclock"
-	SubCommandSyncHostname    = "synchostname"
-	SubCommandSyncIP          = "syncip"
+	SubCommandAddEthernetSettings = "wiredsettings"
+	SubCommandAddWifiSettings     = "addwifisettings"
+	SubCommandEnableWifiPort      = "enablewifiport"
+	SubCommandSetMEBx             = "mebx"
+	SubCommandConfigureTLS        = "tls"
+	SubCommandChangePassword      = "changepassword"
+	SubCommandSyncDeviceInfo      = "syncdeviceinfo"
+	SubCommandSyncClock           = "syncclock"
+	SubCommandSyncHostname        = "synchostname"
+	SubCommandSyncIP              = "syncip"
 
 	// Return Codes
 	Success ReturnCode = 0


### PR DESCRIPTION
### Flows to test
rpc configure addwiredsettings -dhcp -ipsync

rpc configure addwiredsettings -staticip -ipsync

rpc configure addwiredsettings -staticip -ipaddress 192.168.1.7 -netmask 255.255.255.0 -gateway 192.168.1.1 -primarydns 8.8.8.8

rpc configure addwiredsettings -staticip -ipaddress 192.168.1.7 -netmask 255.255.255.0 -gateway 192.168.1.1 -primarydns 8.8.8.8 -secondarydns 4.4.4.4

rpc configure addwiredsettings -config [pathToConfig.yaml]

### Invalid parameters to test
rpc configure addwiredsettings -dhcp

rpc configure addwiredsettings

rpc configure addwiredsettings -staticip -ipaddress 192.168.1.7
