### PR TITLE
fix: removes duplicate printing for -help flag on maintenance commands

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,7 +87,9 @@ func main() {
 
 func handleErrorAndExit(err error) {
 	if customErr, ok := err.(utils.CustomError); ok {
-		log.Error(customErr.Error())
+		if err != utils.HelpRequested {
+			log.Error(customErr.Error())
+		}
 		os.Exit(customErr.Code)
 	} else {
 		log.Error(err.Error())

--- a/internal/flags/maintenance.go
+++ b/internal/flags/maintenance.go
@@ -91,14 +91,22 @@ func (f *Flags) handleMaintenanceCommand() error {
 }
 
 func (f *Flags) handleMaintenanceSyncClock() error {
-	if err := f.amtMaintenanceSyncClockCommand.Parse(f.commandLineArgs[3:]); err != nil {
+	err := f.amtMaintenanceSyncClockCommand.Parse(f.commandLineArgs[3:])
+	if err != nil {
+		if err.Error() == utils.HelpRequested.Message {
+			return utils.HelpRequested
+		}
 		return utils.IncorrectCommandLineParameters
 	}
 	return nil
 }
 
 func (f *Flags) handleMaintenanceSyncDeviceInfo() error {
-	if err := f.amtMaintenanceSyncDeviceInfoCommand.Parse(f.commandLineArgs[3:]); err != nil {
+	err := f.amtMaintenanceSyncDeviceInfoCommand.Parse(f.commandLineArgs[3:])
+	if err != nil {
+		if err.Error() == utils.HelpRequested.Message {
+			return utils.HelpRequested
+		}
 		return utils.IncorrectCommandLineParameters
 	}
 	return nil
@@ -106,8 +114,11 @@ func (f *Flags) handleMaintenanceSyncDeviceInfo() error {
 
 func (f *Flags) handleMaintenanceSyncHostname() error {
 	var err error
-	if err = f.amtMaintenanceSyncHostnameCommand.Parse(f.commandLineArgs[3:]); err != nil {
-		f.amtMaintenanceSyncHostnameCommand.Usage()
+	err = f.amtMaintenanceSyncHostnameCommand.Parse(f.commandLineArgs[3:])
+	if err != nil {
+		if err.Error() == utils.HelpRequested.Message {
+			return utils.HelpRequested
+		}
 		return utils.IncorrectCommandLineParameters
 	}
 	amtCommand := amt.NewAMTCommand()
@@ -149,8 +160,11 @@ func (f *Flags) handleMaintenanceSyncIP() error {
 	f.amtMaintenanceSyncIPCommand.Func("primarydns", "Primary DNS to be assigned to AMT", validateIP(&f.IpConfiguration.PrimaryDns))
 	f.amtMaintenanceSyncIPCommand.Func("secondarydns", "Secondary DNS to be assigned to AMT", validateIP(&f.IpConfiguration.SecondaryDns))
 
-	if err := f.amtMaintenanceSyncIPCommand.Parse(f.commandLineArgs[3:]); err != nil {
-		f.amtMaintenanceSyncIPCommand.Usage()
+	err := f.amtMaintenanceSyncIPCommand.Parse(f.commandLineArgs[3:])
+	if err != nil {
+		if err.Error() == utils.HelpRequested.Message {
+			return utils.HelpRequested
+		}
 		// Parse the error message to find the problematic flag.
 		// The problematic flag is of the following format '-' followed by flag name and then a ':'
 		re := regexp.MustCompile(`-.*:`)
@@ -215,8 +229,11 @@ func (f *Flags) handleMaintenanceSyncIP() error {
 
 func (f *Flags) handleMaintenanceSyncChangePassword() error {
 	f.amtMaintenanceChangePasswordCommand.StringVar(&f.StaticPassword, "static", "", "specify a new password for AMT")
-	if err := f.amtMaintenanceChangePasswordCommand.Parse(f.commandLineArgs[3:]); err != nil {
-		f.amtMaintenanceChangePasswordCommand.Usage()
+	err := f.amtMaintenanceChangePasswordCommand.Parse(f.commandLineArgs[3:])
+	if err != nil {
+		if err.Error() == utils.HelpRequested.Message {
+			return utils.HelpRequested
+		}
 		return utils.IncorrectCommandLineParameters
 	}
 	return nil

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -59,6 +59,7 @@ var IncorrectPermissions = CustomError{Code: 1, Message: "IncorrectPermissions"}
 var HECIDriverNotDetected = CustomError{Code: 2, Message: "HECIDriverNotDetected"}
 var AmtNotDetected = CustomError{Code: 3, Message: "AmtNotDetected"}
 var AmtNotReady = CustomError{Code: 4, Message: "AmtNotReady"}
+var HelpRequested = CustomError{Code: 5, Message: "flag: help requested"}
 var GenericFailure = CustomError{Code: 10, Message: "GenericFailure"}
 
 // (20-69) Input errors to RPC


### PR DESCRIPTION
All maintenance command should
* Work as normal
* Print usage once with no errors when using the -h or -help flags
* Print usage once with `IncorrectCommandLineParameters` when using an incorrect flag