### PR TITLE
build(gh-actions): Add linker options to go build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build rpc as library
-      run: go build -buildmode=c-shared -o rpc.so ./cmd   
+      run: go build -ldflags "-w -s" -buildmode=c-shared -o rpc.so ./cmd   
     - name: Restore dependencies
       run: cd samples/dotnet && dotnet restore
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,12 @@ jobs:
       # Runs a single command using the runners shell
       - name: build go
         if: ${{ matrix.os == 'windows-2019' }}
-        run: go build -o rpc.exe ./cmd
+        run: go build -ldflags "-w -s" -o rpc.exe ./cmd
       
       # Runs a single command using the runners shell
       - name: build go
         if: ${{ matrix.os != 'windows-2019' }}
-        run: go build -o rpc ./cmd
+        run: go build -ldflags "-w -s" -o rpc ./cmd
 
       - name: GitHub Upload Release Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
Add linker options to go build. Test for functionality and reduce binary size for .exe and .dll/.so library.