### PR TITLE
fix(cli): Resolve FQDN on Linux machines with short hostnames

### DIFF
--- a/internal/amt/linux.go
+++ b/internal/amt/linux.go
@@ -9,18 +9,42 @@
 package amt
 
 import (
+	"net"
 	"os"
 	"strings"
 )
 
 func (amt AMTCommand) GetOSDNSSuffix() (string, error) {
+	fqdn, err := getFQDN()
+	if err != nil {
+		return "", err
+	}
+	splitName := strings.SplitAfterN(fqdn, ".", 2)
+	if len(splitName) == 2 {
+		return splitName[1], nil
+	}
+	return fqdn, err
+}
+
+func getFQDN() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", err
 	}
-	splitName := strings.SplitAfterN(hostname, ".", 2)
-	if len(splitName) == 2 {
-		return splitName[1], nil
+
+	if strings.Contains(hostname, ".") {
+		return hostname, nil
 	}
-	return hostname, err
+
+	addrs, err := net.LookupHost(hostname)
+	if err != nil {
+		return "", err
+	}
+
+	names, err := net.LookupAddr(addrs[0])
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(names[0], "."), nil
 }


### PR DESCRIPTION
This patches `GetOSDNSSuffix()` for Linux so that it correctly resolves the machine's FQDN even if it uses only a short hostname. The implementation is inspired by the implementation of [hostname -f](https://sources.debian.org/src/hostname/3.23%2Bnmu2/hostname.c/#L336).

If the host is already configured with an FQDN, it is returned without further lookups.

Resolves #189 