### PR TITLE
fix: Use OS DNS suffix when DNS suffix set in MEBx is empty-like

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # **********************************************************************
 
-FROM golang:1.23-alpine@sha256:04ec5618ca64098b8325e064aa1de2d3efbbd022a3ac5554d49d5ece99d41ad5 as builder
+FROM golang:1.23-alpine@sha256:c23339199a08b0e12032856908589a6d41a0dab141b8b3b21f156fc571a3f1d3 as builder
 
 RUN apk update && apk upgrade && apk add --no-cache git
 

--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -12,6 +12,7 @@ import (
 	"rpc/internal/flags"
 	"rpc/internal/local"
 	"rpc/pkg/utils"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -129,6 +130,9 @@ func (p Payload) createPayload(dnsSuffix string, hostname string, amtTimeout tim
 		payload.FQDN = dnsSuffix
 	} else {
 		payload.FQDN, _ = p.AMT.GetDNSSuffix()
+		// Trim whitespace and a trailing . because MEBx may not allow
+		// unsetting the DNS suffix entry by setting it to an empty string
+		payload.FQDN = strings.TrimSuffix(strings.TrimSpace(payload.FQDN), ".")
 		if payload.FQDN == "" {
 			payload.FQDN, _ = p.AMT.GetOSDNSSuffix()
 		}


### PR DESCRIPTION
Should the OS DNS suffix always be used when the DNS suffix set on AMT via MEBx is an invalid FQDN?

This change currently ignores whitespace and a trailing `.` to allow "unsetting" in MEBx by setting the DNS suffix to either `" "` or `"."` (NOTE: cannot actually set to `.` in my version of MEBx).

At least in my version of MEBx, setting to `""` (an empty string) is not accepted.