### PR TITLE
refactor: moves to wsl_v5 for linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters:
     - unconvert
     - unparam    
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     cyclop:
       max-complexity: 15
@@ -68,6 +68,10 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:

--- a/internal/amt/commands.go
+++ b/internal/amt/commands.go
@@ -150,7 +150,6 @@ func NewAMTCommand() AMTCommand {
 func (amt AMTCommand) Initialize() error {
 	// initialize HECI interface
 	err := amt.PTHI.Open(false)
-
 	if err != nil {
 		if err.Error() == "The handle is invalid." {
 			return utils.HECIDriverNotDetected //, errors.New("AMT not found: MEI/driver is missing or the call to the HECI driver failed")

--- a/internal/certs/embed.go
+++ b/internal/certs/embed.go
@@ -51,8 +51,8 @@ func LoadRootCAPoolwithFS(fs FileSystem) (*x509.CertPool, error) {
 	for _, certFile := range certFiles {
 		if !certFile.IsDir() {
 			certPath := "trustedstore/" + certFile.Name()
-			certData, err := fs.ReadFile(certPath)
 
+			certData, err := fs.ReadFile(certPath)
 			if err != nil {
 				log.Error("Failed to read file: ", certPath, " Error: ", err)
 

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -509,7 +509,6 @@ func (s *InfoService) getOSIPAddress(macAddr string) string {
 		}
 
 		val, err := strconv.ParseUint(part, 16, 8)
-
 		if err != nil {
 			return notFoundIP
 		}

--- a/internal/commands/version_test.go
+++ b/internal/commands/version_test.go
@@ -69,6 +69,7 @@ func TestVersionCmd_Run_PlainText(t *testing.T) {
 				assert.True(t, json.Valid(output), "Output should be valid JSON")
 
 				var info map[string]string
+
 				err := json.Unmarshal(output, &info)
 				assert.NoError(t, err)
 
@@ -120,6 +121,7 @@ func TestVersionCmd_Run_JSONStructure(t *testing.T) {
 
 	// Parse JSON
 	var result map[string]string
+
 	err = json.Unmarshal(output, &result)
 	assert.NoError(t, err)
 
@@ -284,6 +286,7 @@ func TestVersionCmd_Run_UtilsIntegration(t *testing.T) {
 			// Verify that utils constants are being used correctly
 			if tt.jsonOutput {
 				var info map[string]string
+
 				err := json.Unmarshal(output, &info)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, info["app"])

--- a/internal/flags/configure.go
+++ b/internal/flags/configure.go
@@ -455,6 +455,7 @@ func (f *Flags) handleConfigureTLS() error {
 	tlsModeUsage := fmt.Sprintf("TLS authentication usage model (%s) (default %s)", TLSModesToString(), f.ConfigTLSInfo.TLSMode)
 	fs.Func("mode", tlsModeUsage, func(flagValue string) error {
 		var e error
+
 		f.ConfigTLSInfo.TLSMode, e = ParseTLSMode(flagValue)
 
 		return e

--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -150,7 +150,9 @@ func (lme *LMEConnection) Listen() {
 	go func() {
 		lme.Session.Timer = time.NewTimer(2 * time.Second)
 		<-lme.Session.Timer.C
+
 		lme.Session.DataBuffer <- lme.Session.Tempdata
+
 		lme.Session.Tempdata = []byte{}
 
 		var bin_buf bytes.Buffer

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -113,10 +113,10 @@ func (lms *LMSConnection) Listen() {
 
 	for {
 		n, err := lms.Connection.Read(tmp)
-
 		if err != nil {
 			if err != io.EOF && !strings.ContainsAny(err.Error(), "i/o timeout") {
 				log.Println("read error:", err)
+
 				lms.errors <- err
 			}
 
@@ -125,6 +125,7 @@ func (lms *LMSConnection) Listen() {
 
 		buf = append(buf, tmp[:n]...)
 	}
+
 	lms.data <- buf
 
 	log.Trace("done listening")

--- a/internal/lm/service_test.go
+++ b/internal/lm/service_test.go
@@ -17,6 +17,7 @@ func TestNewLMSConnection(t *testing.T) {
 
 	lme := NewLMSConnection("::1", "16992", false, lmDataChannel, lmErrorChannel, 0, true)
 	defer lme.Close()
+
 	assert.Equal(t, lmDataChannel, lme.data)
 	assert.Equal(t, lmErrorChannel, lme.errors)
 	assert.Equal(t, "::1", lme.address)
@@ -28,6 +29,7 @@ func TestInitialize(t *testing.T) {
 	err := lms.Initialize()
 
 	defer lms.Close()
+
 	assert.Error(t, err)
 }
 
@@ -37,6 +39,7 @@ func TestConnect(t *testing.T) {
 	err := lms.Connect()
 
 	defer lms.Close()
+
 	assert.NoError(t, err)
 }
 
@@ -78,6 +81,7 @@ func TestListen(t *testing.T) {
 			data := <-lms.data
 			if len(data) > 0 {
 				assert.Equal(t, []byte("data"), data)
+
 				wait2 <- true
 
 				break

--- a/internal/local/Certificates_test.go
+++ b/internal/local/Certificates_test.go
@@ -81,7 +81,6 @@ func TestGetCertificates(t *testing.T) {
 			tc.setupMocks(mockWsman)
 
 			response, err := service.GetCertificates()
-
 			if tc.err != nil {
 				assert.Error(t, err)
 			} else {

--- a/internal/local/activate.go
+++ b/internal/local/activate.go
@@ -234,7 +234,6 @@ func (service *ProvisioningService) ActivateCCM(tlsConfig *tls.Config) error {
 	// If TLS is enforced, commit changes
 	if service.flags.LocalTlsEnforced {
 		err := service.CCMCommit(tlsConfig)
-
 		if err != nil {
 			return utils.ActivationFailed
 		}
@@ -263,7 +262,6 @@ func (service *ProvisioningService) CCMCommit(tlsConfig *tls.Config) error {
 		log.Info("Putting the device back to pre-provisioning mode")
 
 		_, err = service.interfacedWsmanMessage.Unprovision(1)
-
 		if err != nil {
 			log.Error("Status: Unable to deactivate ", err)
 		}

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -501,7 +501,6 @@ func (g *GoWSMANMessages) AddMPS(password string, server string, port int) (resp
 	}
 
 	result, err := g.wsmanMessages.AMT.RemoteAccessService.AddMPS(mpsServer)
-
 	if err != nil {
 		return result.Body.AddMpServerResponse, err
 	}

--- a/internal/local/configure.go
+++ b/internal/local/configure.go
@@ -106,7 +106,6 @@ func (service *ProvisioningService) ClearCIRA() error {
 	}
 
 	results, err := service.interfacedWsmanMessage.GetMPSSAP()
-
 	if err != nil {
 		return err
 	}

--- a/internal/local/ethernet.go
+++ b/internal/local/ethernet.go
@@ -295,8 +295,8 @@ func (service *ProvisioningService) AddCertsUsingEnterpriseAssistant(ieee8021xCo
 		ieee8021xConfig.ClientCert = ""
 		ieee8021xConfig.Username = reqResponse.Response.Username
 		ieee8021xConfig.Password = reqResponse.Response.Password
-		handles.rootCertHandle, err = service.GetTrustedRootCertHandle(securitySettings, reqResponse.Response.RootCert)
 
+		handles.rootCertHandle, err = service.GetTrustedRootCertHandle(securitySettings, reqResponse.Response.RootCert)
 		if err != nil {
 			return handles, ieee8021xConfig, utils.WSMANMessageError
 		}
@@ -348,8 +348,8 @@ func (service *ProvisioningService) AddCertsUsingEnterpriseAssistant(ieee8021xCo
 	}
 
 	ieee8021xConfig.Username = eaResponse.Response.Username
-	handles.clientCertHandle, err = service.GetClientCertHandle(securitySettings, eaResponse.Response.Certificate)
 
+	handles.clientCertHandle, err = service.GetClientCertHandle(securitySettings, eaResponse.Response.Certificate)
 	if err != nil {
 		return handles, ieee8021xConfig, utils.WSMANMessageError
 	}

--- a/internal/local/opstate_test.go
+++ b/internal/local/opstate_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestCheckAndEnableAMT(t *testing.T) {
 	var errMockTimeout = errors.New("wait timeout while sending data")
+
 	tests := []struct {
 		name             string
 		skipIPRenewal    bool

--- a/internal/local/wifi.go
+++ b/internal/local/wifi.go
@@ -164,8 +164,8 @@ func (service *ProvisioningService) ProcessWifiConfig(wifiCfg *config.WifiConfig
 
 func (service *ProvisioningService) setIeee8021xConfig(ieee8021xConfig *config.Ieee8021xConfig) (ieee8021xSettings models.IEEE8021xSettings, handles Handles, err error) {
 	handles = Handles{}
-	securitySettings, err := service.GetCertificates()
 
+	securitySettings, err := service.GetCertificates()
 	if err != nil {
 		return ieee8021xSettings, handles, utils.WiFiConfigurationFailed
 	}

--- a/internal/local/windows.go
+++ b/internal/local/windows.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
-
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,7 +20,6 @@ func (n *RealOSNetworker) RenewDHCPLease() error {
 	cmd := exec.Command("ipconfig", "/renew")
 
 	err := cmd.Run()
-
 	if err != nil {
 		log.Error("Error renewing DHCP lease:", err)
 

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -46,7 +46,6 @@ func NewExecutor(flags flags.Flags) (Executor, error) {
 
 	// TEST CONNECTION TO SEE IF LMS EXISTS
 	err := client.localManagement.Connect()
-
 	if err != nil {
 		if flags.LocalTlsEnforced {
 			return client, utils.LMSConnectionFailed

--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -127,8 +127,8 @@ func (p Payload) createPayload(dnsSuffix string, hostname string, amtTimeout tim
 	}
 
 	payload.Client = utils.ClientName
-	hashes, err := p.AMT.GetCertificateHashes()
 
+	hashes, err := p.AMT.GetCertificateHashes()
 	if err != nil {
 		return payload, err
 	}
@@ -167,8 +167,8 @@ func (p Payload) CreateMessageRequest(flags flags.Flags) (Message, error) {
 		Message:         "ok",
 		TenantID:        flags.TenantID,
 	}
-	payload, err := p.createPayload(flags.DNS, flags.Hostname, flags.AMTTimeoutDuration)
 
+	payload, err := p.createPayload(flags.DNS, flags.Hostname, flags.AMTTimeoutDuration)
 	if err != nil {
 		return message, err
 	}

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -279,6 +279,7 @@ func TestCreateMessageRequestFriendlyName(t *testing.T) {
 	assert.NoError(t, decodeErr)
 
 	var m map[string]interface{}
+
 	unmarshalErr := json.Unmarshal(decodedBytes, &m)
 	assert.NoError(t, unmarshalErr)
 	assert.Equal(t, m["friendlyName"], expectedName)
@@ -292,6 +293,7 @@ func TestCreateMessageRequestWithoutFriendlyName(t *testing.T) {
 	assert.NoError(t, decodeErr)
 
 	var m map[string]interface{}
+
 	unmarshalErr := json.Unmarshal(decodedBytes, &m)
 	assert.NoError(t, unmarshalErr)
 

--- a/internal/rps/rps.go
+++ b/internal/rps/rps.go
@@ -172,6 +172,7 @@ func (amt *AMTActivationServer) Listen() chan []byte {
 
 				break
 			}
+
 			dataChannel <- message
 		}
 	}()

--- a/internal/rps/rps_test.go
+++ b/internal/rps/rps_test.go
@@ -153,6 +153,7 @@ func TestConnect(t *testing.T) {
 	err := server.Connect(true)
 
 	defer server.Close()
+
 	assert.NoError(t, err)
 }
 func TestSend(t *testing.T) {
@@ -160,6 +161,7 @@ func TestSend(t *testing.T) {
 	err := server.Connect(true)
 
 	defer server.Close()
+
 	assert.NoError(t, err)
 
 	message := Message{
@@ -172,6 +174,7 @@ func TestListen(t *testing.T) {
 	err := server.Connect(true)
 
 	defer server.Close()
+
 	assert.NoError(t, err)
 
 	var wgAll sync.WaitGroup

--- a/internal/smb/samba.go
+++ b/internal/smb/samba.go
@@ -105,8 +105,8 @@ func (s *Service) FetchFileContents(url string) ([]byte, error) {
 func (s *Service) ParseUrl(url string) (Properties, error) {
 	p := Properties{}
 	p.Url = url
-	u, err := netURL.Parse(url)
 
+	u, err := netURL.Parse(url)
 	if err != nil {
 		return p, err
 	}

--- a/pkg/pthi/commands.go
+++ b/pkg/pthi/commands.go
@@ -205,8 +205,8 @@ func (pthi Command) GetIsAMTEnabled() (uint8, error) {
 	var bin_buf bytes.Buffer
 
 	binary.Write(&bin_buf, binary.LittleEndian, command)
-	result, err := pthi.Call(bin_buf.Bytes(), uint32(bin_buf.Len()))
 
+	result, err := pthi.Call(bin_buf.Bytes(), uint32(bin_buf.Len()))
 	if err != nil {
 		return uint8(0), err
 	}

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -352,7 +352,6 @@ func TestOrderCertsChain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ordered, err := OrderCertsChain(tt.certs)
-
 			if tt.wantErr != nil {
 				if err == nil || !contains(err.Error(), tt.wantErr.Error()) {
 					t.Errorf("expected error containing %q, got %v", tt.wantErr.Error(), err)

--- a/pkg/windows/setupapi.go
+++ b/pkg/windows/setupapi.go
@@ -57,8 +57,9 @@ var (
 )
 
 func SetupDiGetClassDevs(class *windows.GUID, enum *uint16, parent syscall.Handle, flags uint32) (devInfoSet syscall.Handle, err error) {
-	r0, _, e1 := syscall.Syscall6(procSetupDiGetClassDevsW.Addr(), 4, uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(enum)), uintptr(parent), uintptr(flags), 0, 0)
+	r0, _, e1 := syscall.SyscallN(procSetupDiGetClassDevsW.Addr(), uintptr(unsafe.Pointer(class)), uintptr(unsafe.Pointer(enum)), uintptr(parent), uintptr(flags))
 	devInfoSet = syscall.Handle(r0)
+
 	if devInfoSet == syscall.InvalidHandle {
 		if e1 != 0 {
 			err = error(e1)
@@ -66,6 +67,7 @@ func SetupDiGetClassDevs(class *windows.GUID, enum *uint16, parent syscall.Handl
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
@@ -74,7 +76,8 @@ func SetupDiGetDeviceRegistryProperty(devInfoSet syscall.Handle, diData *SpDevin
 	if len(buf) > 0 {
 		_p0 = &buf[0]
 	}
-	r1, _, e1 := syscall.Syscall9(procSetupDiGetDeviceRegistryPropertyW.Addr(), 7, uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(prop), uintptr(unsafe.Pointer(regDataType)), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(size)), 0, 0)
+
+	r1, _, e1 := syscall.SyscallN(procSetupDiGetDeviceRegistryPropertyW.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(prop), uintptr(unsafe.Pointer(regDataType)), uintptr(unsafe.Pointer(_p0)), uintptr(len(buf)), uintptr(unsafe.Pointer(size)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -82,11 +85,12 @@ func SetupDiGetDeviceRegistryProperty(devInfoSet syscall.Handle, diData *SpDevin
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiEnumDeviceInfo(devInfoSet syscall.Handle, index uint32, diData *SpDevinfoData) (err error) {
-	r1, _, e1 := syscall.Syscall(procSetupDiEnumDeviceInfo.Addr(), 3, uintptr(devInfoSet), uintptr(index), uintptr(unsafe.Pointer(diData)))
+	r1, _, e1 := syscall.SyscallN(procSetupDiEnumDeviceInfo.Addr(), uintptr(devInfoSet), uintptr(index), uintptr(unsafe.Pointer(diData)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -94,11 +98,12 @@ func SetupDiEnumDeviceInfo(devInfoSet syscall.Handle, index uint32, diData *SpDe
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiCreateDeviceInfo(devInfoSet syscall.Handle, devName *uint16, g *windows.GUID, devDesc *uint16, hwnd uintptr, cflags uint32, dataOut *SpDevinfoData) (err error) {
-	r1, _, e1 := syscall.Syscall9(procSetupDiCreateDeviceInfoW.Addr(), 7, uintptr(devInfoSet), uintptr(unsafe.Pointer(devName)), uintptr(unsafe.Pointer(g)), uintptr(unsafe.Pointer(devDesc)), uintptr(hwnd), uintptr(cflags), uintptr(unsafe.Pointer(dataOut)), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procSetupDiCreateDeviceInfoW.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(devName)), uintptr(unsafe.Pointer(g)), uintptr(unsafe.Pointer(devDesc)), hwnd, uintptr(cflags), uintptr(unsafe.Pointer(dataOut)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -106,12 +111,14 @@ func SetupDiCreateDeviceInfo(devInfoSet syscall.Handle, devName *uint16, g *wind
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiCreateDeviceInfoList(g *windows.GUID, hwnd uintptr) (devInfoSet syscall.Handle, err error) {
-	r0, _, e1 := syscall.Syscall(procSetupDiCreateDeviceInfoList.Addr(), 2, uintptr(unsafe.Pointer(g)), uintptr(hwnd), 0)
+	r0, _, e1 := syscall.SyscallN(procSetupDiCreateDeviceInfoList.Addr(), uintptr(unsafe.Pointer(g)), hwnd)
 	devInfoSet = syscall.Handle(r0)
+
 	if devInfoSet == syscall.InvalidHandle {
 		if e1 != 0 {
 			err = error(e1)
@@ -119,11 +126,12 @@ func SetupDiCreateDeviceInfoList(g *windows.GUID, hwnd uintptr) (devInfoSet sysc
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiSetDeviceRegistryProperty(devInfoSet syscall.Handle, data *SpDevinfoData, prop uint32, buf *byte, sz uint32) (err error) {
-	r1, _, e1 := syscall.Syscall6(procSetupDiSetDeviceRegistryPropertyW.Addr(), 5, uintptr(devInfoSet), uintptr(unsafe.Pointer(data)), uintptr(prop), uintptr(unsafe.Pointer(buf)), uintptr(sz), 0)
+	r1, _, e1 := syscall.SyscallN(procSetupDiSetDeviceRegistryPropertyW.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(data)), uintptr(prop), uintptr(unsafe.Pointer(buf)), uintptr(sz))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -131,11 +139,12 @@ func SetupDiSetDeviceRegistryProperty(devInfoSet syscall.Handle, data *SpDevinfo
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiCallClassInstaller(installFn uintptr, devInfoSet syscall.Handle, data *SpDevinfoData) (err error) {
-	r1, _, e1 := syscall.Syscall(procSetupDiCallClassInstaller.Addr(), 3, uintptr(installFn), uintptr(devInfoSet), uintptr(unsafe.Pointer(data)))
+	r1, _, e1 := syscall.SyscallN(procSetupDiCallClassInstaller.Addr(), installFn, uintptr(devInfoSet), uintptr(unsafe.Pointer(data)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -143,11 +152,12 @@ func SetupDiCallClassInstaller(installFn uintptr, devInfoSet syscall.Handle, dat
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiDestroyDeviceInfoList(devInfoSet syscall.Handle) (err error) {
-	r1, _, e1 := syscall.Syscall(procSetupDiDestroyDeviceInfoList.Addr(), 1, uintptr(devInfoSet), 0, 0)
+	r1, _, e1 := syscall.SyscallN(procSetupDiDestroyDeviceInfoList.Addr(), uintptr(devInfoSet))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -155,6 +165,7 @@ func SetupDiDestroyDeviceInfoList(devInfoSet syscall.Handle) (err error) {
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
@@ -163,7 +174,8 @@ func SetupDiGetINFClass(infPath *uint16, guid *windows.GUID, className []uint16,
 	if len(className) > 0 {
 		_p0 = &className[0]
 	}
-	r1, _, e1 := syscall.Syscall6(procSetupDiGetINFClassW.Addr(), 5, uintptr(unsafe.Pointer(infPath)), uintptr(unsafe.Pointer(guid)), uintptr(unsafe.Pointer(_p0)), uintptr(len(className)), uintptr(unsafe.Pointer(reqSz)), 0)
+
+	r1, _, e1 := syscall.SyscallN(procSetupDiGetINFClassW.Addr(), uintptr(unsafe.Pointer(infPath)), uintptr(unsafe.Pointer(guid)), uintptr(unsafe.Pointer(_p0)), uintptr(len(className)), uintptr(unsafe.Pointer(reqSz)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -171,12 +183,14 @@ func SetupDiGetINFClass(infPath *uint16, guid *windows.GUID, className []uint16,
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiOpenDevRegKey(devInfoSet syscall.Handle, diData *SpDevinfoData, scope uint32, hwProfile uint32, keyType uint32, desiredAccess uint32) (h syscall.Handle, err error) {
-	r0, _, e1 := syscall.Syscall6(procSetupDiOpenDevRegKey.Addr(), 6, uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(scope), uintptr(hwProfile), uintptr(keyType), uintptr(desiredAccess))
+	r0, _, e1 := syscall.SyscallN(procSetupDiOpenDevRegKey.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(scope), uintptr(hwProfile), uintptr(keyType), uintptr(desiredAccess))
 	h = syscall.Handle(r0)
+
 	if h == syscall.InvalidHandle {
 		if e1 != 0 {
 			err = error(e1)
@@ -184,6 +198,7 @@ func SetupDiOpenDevRegKey(devInfoSet syscall.Handle, diData *SpDevinfoData, scop
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
@@ -192,7 +207,8 @@ func SetupDiGetDeviceInstanceId(devInfoSet syscall.Handle, diData *SpDevinfoData
 	if len(id) > 0 {
 		_p0 = &id[0]
 	}
-	r1, _, e1 := syscall.Syscall6(procSetupDiGetDeviceInstanceIdW.Addr(), 5, uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(unsafe.Pointer(_p0)), uintptr(len(id)), uintptr(unsafe.Pointer(reqSz)), 0)
+
+	r1, _, e1 := syscall.SyscallN(procSetupDiGetDeviceInstanceIdW.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(diData)), uintptr(unsafe.Pointer(_p0)), uintptr(len(id)), uintptr(unsafe.Pointer(reqSz)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -200,12 +216,14 @@ func SetupDiGetDeviceInstanceId(devInfoSet syscall.Handle, diData *SpDevinfoData
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiEnumDeviceInterfaces(devInfoSet syscall.Handle, deviceInfoData *SpDevinfoData, class *windows.GUID, memberIndex uint32, deviceInterfaceData *SpDevInterfaceData) (idk syscall.Handle, err error) {
-	r0, _, e1 := syscall.Syscall6(procSetupDiEnumDeviceInterfaces.Addr(), 5, uintptr(devInfoSet), uintptr(unsafe.Pointer(deviceInfoData)), uintptr(unsafe.Pointer(class)), uintptr(memberIndex), uintptr(unsafe.Pointer(deviceInterfaceData)), 0)
+	r0, _, e1 := syscall.SyscallN(procSetupDiEnumDeviceInterfaces.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(deviceInfoData)), uintptr(unsafe.Pointer(class)), uintptr(memberIndex), uintptr(unsafe.Pointer(deviceInterfaceData)))
 	devInfoSet = syscall.Handle(r0)
+
 	if devInfoSet == syscall.InvalidHandle {
 		if e1 != 0 {
 			err = error(e1)
@@ -213,11 +231,12 @@ func SetupDiEnumDeviceInterfaces(devInfoSet syscall.Handle, deviceInfoData *SpDe
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }
 
 func SetupDiGetDeviceInterfaceDetail(devInfoSet syscall.Handle, dintfdata *SpDevInterfaceData, detail *uint16, detailSize uint32, reqsize *uint32, devInfData *SpDevinfoData) (err error) {
-	r1, _, e1 := syscall.Syscall6(procSetupDiGetDeviceInterfaceDetailW.Addr(), 6, uintptr(devInfoSet), uintptr(unsafe.Pointer(dintfdata)), uintptr(unsafe.Pointer(detail)), uintptr(detailSize), uintptr(unsafe.Pointer(reqsize)), uintptr(unsafe.Pointer(devInfData)))
+	r1, _, e1 := syscall.SyscallN(procSetupDiGetDeviceInterfaceDetailW.Addr(), uintptr(devInfoSet), uintptr(unsafe.Pointer(dintfdata)), uintptr(unsafe.Pointer(detail)), uintptr(detailSize), uintptr(unsafe.Pointer(reqsize)), uintptr(unsafe.Pointer(devInfData)))
 
 	if r1 == 0 {
 		if e1 != 0 {
@@ -226,5 +245,6 @@ func SetupDiGetDeviceInterfaceDetail(devInfoSet syscall.Handle, dintfdata *SpDev
 			err = syscall.EINVAL
 		}
 	}
+
 	return
 }


### PR DESCRIPTION
- migrates syscall functions off of deprecated apis.