### PR TITLE
ci: configure 2.x maintenance branch to own entire 2.x range

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,8 +3,8 @@
     "main",
     {
       "name": "2.x.x",
-      "range": "2.48.x",
-      "channel": "2.48.x"
+      "range": "2.x",
+      "channel": "2.x"
     }
   ],
   "plugins": [


### PR DESCRIPTION
- Updates maintenance branch range from 2.48.x to 2.x
- This allows 2.x.x branch to release any 2.x version
- Main branch will jump to 3.0.0 on next breaking change