### PR TITLE
fix: enable AMT 19+ deactivation with mutual TLS and hostname bypass

### DIFF
--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -520,8 +520,10 @@ func (service *LocalActivationService) setupACMTLSConfig() (*tls.Config, error) 
 		certsAndKeys, err := service.convertPfxToObject(service.config.ProvisioningCert, service.config.ProvisioningCertPwd)
 		if err != nil {
 			log.Error("Failed to convert provisioning certificate:", err)
+
 			return nil, err
 		}
+
 		log.Info("Successfully loaded provisioning certificate, chain length:", len(certsAndKeys.certs))
 
 		// Add client certificate to TLS config for mutual TLS
@@ -541,6 +543,7 @@ func (service *LocalActivationService) setupACMTLSConfig() (*tls.Config, error) 
 		clientCert := tlsCert
 		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			log.Debug("Client certificate requested by server")
+
 			return &clientCert, nil
 		}
 	}
@@ -563,6 +566,7 @@ func (service *LocalActivationService) activateACMWithTLS() error {
 		certsAndKeys, err := service.convertPfxToObject(service.config.ProvisioningCert, service.config.ProvisioningCertPwd)
 		if err != nil {
 			log.Error("Failed to load provisioning certificate for post-activation:", err)
+
 			return fmt.Errorf("failed to load provisioning certificate: %w", err)
 		}
 
@@ -582,6 +586,7 @@ func (service *LocalActivationService) activateACMWithTLS() error {
 		clientCert := tlsCert
 		tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			log.Trace("Client certificate requested by server (post-activation)")
+
 			return &clientCert, nil
 		}
 	}
@@ -701,9 +706,11 @@ func (service *LocalActivationService) activateACMLegacy() error {
 	// cannot be called in pre-provisioning mode. PTHI validates certificate internally.
 	if service.localTLSEnforced && !service.isUpgrade {
 		log.Info("Calling PTHI/MEI StartConfigurationHBased for TLS-enforced activation...")
+
 		certsAndKeys, err := service.convertPfxToObject(service.config.ProvisioningCert, service.config.ProvisioningCertPwd)
 		if err != nil {
 			log.Error("Failed to convert provisioning cert for PTHI:", err)
+
 			return err
 		}
 
@@ -724,6 +731,7 @@ func (service *LocalActivationService) activateACMLegacy() error {
 
 		if controlMode == 2 { // 2 = ACM mode
 			log.Info("ACM activation successful via PTHI/MEI")
+
 			return nil
 		}
 
@@ -748,9 +756,11 @@ func (service *LocalActivationService) activateACMLegacy() error {
 			controlMode, controlErr := service.amtCommand.GetControlMode()
 			if controlErr == nil && controlMode == 2 {
 				log.Info("Activation succeeded - WSMAN connection closed during AMT transition")
+
 				return nil
 			}
 		}
+
 		return utils.ActivationFailedGeneralSettings
 	}
 
@@ -803,8 +813,10 @@ func (service *LocalActivationService) activateACMLegacy() error {
 
 		// Activation was successful
 		log.Info("Activation succeeded despite HostBasedSetupServiceAdmin error")
+
 		return nil
 	}
+
 	log.Info("HostBasedSetupServiceAdmin succeeded")
 
 	return nil

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -25,6 +25,7 @@ func getTestCerts() *certs.CompositeChain {
 		cc, _ := certs.NewCompositeChain("P@ssw0rd")
 		sortaSingletonCerts = &cc
 	}
+
 	return sortaSingletonCerts
 }
 
@@ -967,13 +968,16 @@ func TestLocalActivationService_setupACMTLSConfig_ClientCertCallback(t *testing.
 		certInfo := &tls.CertificateRequestInfo{
 			AcceptableCAs: [][]byte{},
 		}
+
 		cert, err := tlsConfig.GetClientCertificate(certInfo)
 		if err != nil {
 			t.Errorf("GetClientCertificate callback returned error: %v", err)
 		}
+
 		if cert == nil {
 			t.Error("GetClientCertificate callback returned nil certificate")
 		}
+
 		if cert != nil && len(cert.Certificate) == 0 {
 			t.Error("GetClientCertificate callback returned certificate with empty chain")
 		}

--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -134,6 +134,7 @@ func (cmd *AMTBaseCmd) addClientCertificate(tlsConfig *tls.Config) error {
 	clientCert := tlsCert
 	tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		log.Trace("Client certificate requested by server")
+
 		return &clientCert, nil
 	}
 


### PR DESCRIPTION
Added profile loading to deactivate command for client certificates. Added VerifyConnection callback to bypass hostname verification

Addresses #875