### PR TITLE
feat: enables ACM deactivation for AMT 19+

### DIFF
--- a/internal/config/lmsTls.go
+++ b/internal/config/lmsTls.go
@@ -31,6 +31,13 @@ func GetTLSConfig(mode *int, amtCertInfo *amt.SecureHBasedResponse, skipCertChec
 		tlsConfig.VerifyConnection = func(cs tls.ConnectionState) error {
 			return nil
 		}
+		// When the server requests a client certificate (mutual TLS), return nil to indicate
+		// no client certificate is available. This allows deactivation without provisioning cert.
+		tlsConfig.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			log.Trace("Server requested client certificate, responding with no certificate")
+
+			return nil, nil
+		}
 	}
 
 	if *mode == 0 { // pre-provisioning mode

--- a/internal/flags/deactivate.go
+++ b/internal/flags/deactivate.go
@@ -14,6 +14,8 @@ import (
 func (f *Flags) handleDeactivateCommand() error {
 	f.amtDeactivateCommand.BoolVar(&f.Local, "local", false, "Execute command to AMT directly without cloud interaction")
 	f.amtDeactivateCommand.BoolVar(&f.PartialUnprovision, "partial", false, "Partially unprovision the device. Only supported w/ -local flag.")
+	f.amtDeactivateCommand.StringVar(&f.configContentV2, "configv2", "", "specify a config file for ACM deactivation")
+	f.amtDeactivateCommand.StringVar(&f.configV2Key, "configencryptionkey", utils.LookupEnv("CONFIG_ENCRYPTION_KEY"), "provide the 32 byte key to decrypt the config file")
 
 	if len(f.commandLineArgs) == 2 {
 		f.amtDeactivateCommand.PrintDefaults()
@@ -49,6 +51,22 @@ func (f *Flags) handleDeactivateCommand() error {
 			if err := f.ReadPasswordFromUser(); err != nil {
 				return utils.MissingOrIncorrectPassword
 			}
+		}
+	}
+
+	// Load profile if provided for local deactivation
+	if f.Local && f.configContentV2 != "" {
+		if err := f.handleLocalConfigV2(); err != nil {
+			return err
+		}
+
+		// Extract provisioning certificate from profile for ACM deactivation
+		if f.LocalConfigV2.Configuration.AMTSpecific.ProvisioningCert != "" {
+			f.LocalConfig.ACMSettings.ProvisioningCert = f.LocalConfigV2.Configuration.AMTSpecific.ProvisioningCert
+		}
+
+		if f.LocalConfigV2.Configuration.AMTSpecific.ProvisioningCertPwd != "" {
+			f.LocalConfig.ACMSettings.ProvisioningCertPwd = f.LocalConfigV2.Configuration.AMTSpecific.ProvisioningCertPwd
 		}
 	}
 

--- a/internal/local/deactivate.go
+++ b/internal/local/deactivate.go
@@ -8,6 +8,7 @@ package local
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/device-management-toolkit/rpc-go/v2/internal/config"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
@@ -63,27 +64,81 @@ func (service *ProvisioningService) DeactivateACM() (err error) {
 		}
 	}
 
-	tlsConfig := &tls.Config{}
-	if service.flags.LocalTlsEnforced {
+	// Build TLS config with client certificate if profile provided
+	var tlsConfig *tls.Config
+
+	if service.flags.LocalConfig.ACMSettings.ProvisioningCert != "" &&
+		service.flags.LocalConfig.ACMSettings.ProvisioningCertPwd != "" {
+		log.Debug("Building TLS config with client certificate from profile for deactivation")
+
+		// Parse the provisioning certificate
+		certsAndKeys, err := convertPfxToObject(
+			service.flags.LocalConfig.ACMSettings.ProvisioningCert,
+			service.flags.LocalConfig.ACMSettings.ProvisioningCertPwd,
+		)
+		if err != nil {
+			log.Error("Failed to parse provisioning certificate: ", err)
+
+			return err
+		}
+
+		// Build TLS config with the parsed certificate
+		tlsConfig = service.buildTLSConfigWithClientCert(certsAndKeys)
+	} else if service.flags.LocalTlsEnforced || service.flags.SkipCertCheck || service.flags.SkipAmtCertCheck {
+		// Use TLS config with skip flags for certificate verification bypass
 		tlsConfig = config.GetTLSConfig(&service.flags.ControlMode, nil, service.flags.SkipCertCheck || service.flags.SkipAmtCertCheck)
+
+		// Override the GetClientCertificate callback to prevent panic when server requests client cert
+		// Return an empty certificate which causes graceful TLS handshake failure instead of panic
+		tlsConfig.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			log.Trace("Server requested client certificate for deactivation, but none provided")
+			// Return empty cert - server will reject if it requires valid certificate
+			return &tls.Certificate{}, nil
+		}
+	} else {
+		// No TLS enforcement and no skip flags - use empty config
+		tlsConfig = &tls.Config{}
 	}
 
-	err = service.interfacedWsmanMessage.SetupWsmanClient("admin", service.flags.Password, service.flags.LocalTlsEnforced, log.GetLevel() == log.TraceLevel, tlsConfig)
+	err = service.setupWsmanWithConfig("admin", service.flags.Password, tlsConfig)
 	if err != nil {
+		// Provide helpful message if TLS connection fails
+		errMsg := strings.ToLower(err.Error())
+		if strings.Contains(errMsg, "certificate required") || strings.Contains(errMsg, "handshake failure") {
+			log.Error("TLS connection failed. Provide the provisioning certificate used during activation:")
+			log.Error("  sudo ./rpc deactivate -local -configv2 <profile> -configencryptionkey <key>")
+		} else if strings.Contains(errMsg, "certificate") || strings.Contains(errMsg, "tls") {
+			log.Error("TLS connection failed. Try using -n or -skipamtcertcheck flag:")
+			log.Error("  sudo ./rpc deactivate -local -n")
+		}
 		return err
 	}
 
 	if service.flags.PartialUnprovision {
 		_, err := service.interfacedWsmanMessage.PartialUnprovision()
 		if err != nil {
-			log.Error("Status: Unable to partially deactivate ", err)
+			// Check if error is due to mutual TLS certificate requirement
+			errMsg := strings.ToLower(err.Error())
+			if strings.Contains(errMsg, "certificate required") || strings.Contains(errMsg, "handshake failure") {
+				log.Error("TLS connection failed. Provide the provisioning certificate used during activation:")
+				log.Error("  sudo ./rpc deactivate -local -configv2 <profile> -configencryptionkey <key>")
+			} else {
+				log.Error("Status: Unable to partially deactivate ", err)
+			}
 
 			return utils.UnableToDeactivate
 		}
 	} else {
 		_, err = service.interfacedWsmanMessage.Unprovision(1)
 		if err != nil {
-			log.Error("Status: Unable to deactivate ", err)
+			// Check if error is due to mutual TLS certificate requirement
+			errMsg := strings.ToLower(err.Error())
+			if strings.Contains(errMsg, "certificate required") || strings.Contains(errMsg, "handshake failure") {
+				log.Error("TLS connection failed. Provide the provisioning certificate used during activation:")
+				log.Error("  sudo ./rpc deactivate -local -configv2 <profile> -configencryptionkey <key>")
+			} else {
+				log.Error("Status: Unable to deactivate ", err)
+			}
 
 			return utils.UnableToDeactivate
 		}


### PR DESCRIPTION
Enable profile/key deactivation for ACM devices activated with v2.48.0 (mutual TLS enforced AMT 19+ devices).

Addresses #875