### PR TITLE
fix(heci): Add AMT v19+ compatibility with dual-port LMS fallback 

### DIFF
--- a/cmd/rpc/lib.go
+++ b/cmd/rpc/lib.go
@@ -68,6 +68,7 @@ func rpcExec(Input *C.char, Output **C.char, ErrOutput **C.char) int {
 	if err != nil {
 		log.Error(AccessErrMsg)
 		captureAndRestoreStderr()
+
 		return handleError(err)
 	}
 
@@ -81,6 +82,7 @@ func rpcExec(Input *C.char, Output **C.char, ErrOutput **C.char) int {
 	if err != nil {
 		log.Error(err.Error())
 		captureAndRestoreStderr()
+
 		return utils.InvalidParameterCombination.Code
 	}
 
@@ -106,6 +108,7 @@ func rpcExec(Input *C.char, Output **C.char, ErrOutput **C.char) int {
 func handleError(err error) int {
 	if customErr, ok := err.(utils.CustomError); ok {
 		log.Error(customErr.Error())
+
 		return customErr.Code
 	} else {
 		errorMsg := err.Error()
@@ -114,6 +117,7 @@ func handleError(err error) int {
 		if strings.Contains(errorMsg, "unexpected argument") {
 			return utils.InvalidParameterCombination.Code
 		}
+
 		return utils.GenericFailure.Code
 	}
 }


### PR DESCRIPTION
fix(heci): Add AMT v19+ compatibility with dual-port LMS fallback 
- Add bidirectional TLS/non-TLS fallback logic in executor.go to handle
  systems with LMS running on either port 16992 or 16993
- Implement comprehensive EINTR (interrupted system call) retry logic
  in linux.go for improved AMT v19+ compatibility
- Add 2-second delay before LME fallback to prevent MEI resource conflicts
- Fix "device or resource busy" errors on newer AMT firmware versions

Addresses: https://github.com/device-management-toolkit/rpc-go/issues/1065

Signed-off-by: ShradhaGupta31 <shradha.gupta@intel.com>