### PR TITLE
refactor: Implement CSME Flash Log (FLOG) retrieval command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/geoffgarside/ber v1.1.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/kr/text v0.1.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 )

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -339,6 +339,10 @@ func (m *MockAMTCommand) StartConfigurationHBased(params amt.SecureHBasedParamet
 	return amt.SecureHBasedResponse{}, nil
 }
 
+func (m *MockAMTCommand) GetFlog() ([]byte, error) {
+	return []byte{}, nil
+}
+
 func (m *MockAMTCommand) StopConfiguration() (amt.StopConfigurationResponse, error) {
 	if m.shouldErrorOn == "StopConfiguration" {
 		return amt.StopConfigurationResponse{}, errors.New("mock error")

--- a/internal/commands/diagnostics/csme.go
+++ b/internal/commands/diagnostics/csme.go
@@ -1,20 +1,65 @@
 /*********************************************************************
- * Copyright (c) Intel Corporation 2024
+ * Copyright (c) Intel Corporation 2026
  * SPDX-License-Identifier: Apache-2.0
  *********************************************************************/
 
 package diagnostics
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	log "github.com/sirupsen/logrus"
 )
 
 // CSMECmd dumps CSME / firmware flash diagnostics.
 type CSMECmd struct {
 	DiagnosticsBaseCmd
+
+	Flog FlogCmd `cmd:"flog" help:"Retrieve the CSME Flash Log (FLOG) and save it to a file"`
 }
 
-// Run executes the CSME diagnostics command.
+// FlogCmd represents the flog subcommand
+type FlogCmd struct {
+	DiagnosticsBaseCmd
+
+	Output string `help:"Output file path for the FLOG binary data" short:"o" required:""`
+}
+
+// Run executes the CSME diagnostics command (parent command - shows help).
 func (cmd *CSMECmd) Run(ctx *commands.Context) error {
+	return nil
+}
+
+// Run executes the flog command
+func (cmd *FlogCmd) Run(ctx *commands.Context) error {
+	log.Debug("Starting FLOG retrieval")
+
+	// Retrieve the FLOG data
+	flogData, err := ctx.AMTCommand.GetFlog()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve FLOG: %w", err)
+	}
+
+	// Ensure output directory exists
+	outputDir := filepath.Dir(cmd.Output)
+	if outputDir != "." && outputDir != "" {
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
+	}
+
+	// Write the binary FLOG data to file
+	if err := os.WriteFile(cmd.Output, flogData, 0o644); err != nil {
+		return fmt.Errorf("failed to write FLOG file: %w", err)
+	}
+
+	fmt.Printf("CSME Flash Log (FLOG) successfully retrieved\n")
+	fmt.Printf("Output file: %s\n", cmd.Output)
+	fmt.Printf("Size: %d bytes\n", len(flogData))
+	log.Infof("FLOG data saved to: %s", cmd.Output)
+
 	return nil
 }

--- a/internal/commands/diagnostics/csme_test.go
+++ b/internal/commands/diagnostics/csme_test.go
@@ -1,0 +1,163 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package diagnostics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockFlogAMTCommand is a minimal mock for testing FLOG functionality
+// Only GetFlog() is actually used; other methods are stubs to satisfy amt.Interface
+type MockFlogAMTCommand struct {
+	mock.Mock
+}
+
+// GetFlog is the method being tested
+func (m *MockFlogAMTCommand) GetFlog() ([]byte, error) {
+	args := m.Called()
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+// Stub implementations below - required by amt.Interface but not used in these tests
+func (m *MockFlogAMTCommand) Initialize() error                                    { return nil }
+func (m *MockFlogAMTCommand) GetChangeEnabled() (amt.ChangeEnabledResponse, error) { return 0, nil }
+func (m *MockFlogAMTCommand) EnableAMT() error                                     { return nil }
+func (m *MockFlogAMTCommand) DisableAMT() error                                    { return nil }
+func (m *MockFlogAMTCommand) GetVersionDataFromME(key string, timeout time.Duration) (string, error) {
+	return "", nil
+}
+func (m *MockFlogAMTCommand) GetUUID() (string, error)                           { return "", nil }
+func (m *MockFlogAMTCommand) GetControlMode() (int, error)                       { return 0, nil }
+func (m *MockFlogAMTCommand) GetProvisioningState() (int, error)                 { return 0, nil }
+func (m *MockFlogAMTCommand) GetOSDNSSuffix() (string, error)                    { return "", nil }
+func (m *MockFlogAMTCommand) GetDNSSuffix() (string, error)                      { return "", nil }
+func (m *MockFlogAMTCommand) GetCertificateHashes() ([]amt.CertHashEntry, error) { return nil, nil }
+func (m *MockFlogAMTCommand) GetRemoteAccessConnectionStatus() (amt.RemoteAccessStatus, error) {
+	return amt.RemoteAccessStatus{}, nil
+}
+
+func (m *MockFlogAMTCommand) GetLANInterfaceSettings(useWireless bool) (amt.InterfaceSettings, error) {
+	return amt.InterfaceSettings{}, nil
+}
+
+func (m *MockFlogAMTCommand) GetLocalSystemAccount() (amt.LocalSystemAccount, error) {
+	return amt.LocalSystemAccount{}, nil
+}
+func (m *MockFlogAMTCommand) Unprovision() (int, error) { return 0, nil }
+func (m *MockFlogAMTCommand) StartConfigurationHBased(params amt.SecureHBasedParameters) (amt.SecureHBasedResponse, error) {
+	return amt.SecureHBasedResponse{}, nil
+}
+
+func (m *MockFlogAMTCommand) StopConfiguration() (amt.StopConfigurationResponse, error) {
+	return amt.StopConfigurationResponse{}, nil
+}
+
+func TestFlogCommand_Success(t *testing.T) {
+	// Create a temporary directory for test output
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_flog.bin")
+
+	// Mock FLOG data
+	mockFlogData := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	// Setup mock
+	mockAMT := new(MockFlogAMTCommand)
+	mockAMT.On("GetFlog").Return(mockFlogData, nil)
+
+	// Create command
+	cmd := FlogCmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, outputFile)
+
+	// Verify file contents
+	fileData, err := os.ReadFile(outputFile)
+	assert.NoError(t, err)
+	assert.Equal(t, mockFlogData, fileData)
+
+	mockAMT.AssertExpectations(t)
+}
+
+func TestFlogCommand_DirectoryCreation(t *testing.T) {
+	// Create a temporary directory
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "subdir", "nested", "test_flog.bin")
+
+	// Mock FLOG data
+	mockFlogData := []byte{0x01, 0x02, 0x03, 0x04}
+
+	// Setup mock
+	mockAMT := new(MockFlogAMTCommand)
+	mockAMT.On("GetFlog").Return(mockFlogData, nil)
+
+	// Create command
+	cmd := FlogCmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, outputFile)
+
+	mockAMT.AssertExpectations(t)
+}
+
+func TestFlogCommand_GetFlogError(t *testing.T) {
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_flog.bin")
+
+	// Setup mock to return error
+	mockAMT := new(MockFlogAMTCommand)
+	mockAMT.On("GetFlog").Return([]byte{}, assert.AnError)
+
+	// Create command
+	cmd := FlogCmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command - should return error
+	err := cmd.Run(ctx)
+	assert.Error(t, err)
+
+	// Verify file was not created
+	_, statErr := os.Stat(outputFile)
+	assert.True(t, os.IsNotExist(statErr))
+
+	mockAMT.AssertExpectations(t)
+}

--- a/internal/lm/engine_test.go
+++ b/internal/lm/engine_test.go
@@ -33,6 +33,7 @@ func resetMock() {
 }
 
 func (c *MockHECICommands) Init(useLME, useWD bool) error { return initError }
+func (c *MockHECICommands) InitHOTHAM() error             { return initError }
 func (c *MockHECICommands) GetBufferSize() uint32         { return bufferSize } // MaxMessageLength
 func (c *MockHECICommands) SendMessage(buffer []byte, done *uint32) (bytesWritten int, err error) {
 	return sendBytesWritten, sendError

--- a/internal/mocks/amt_mock.go
+++ b/internal/mocks/amt_mock.go
@@ -278,6 +278,15 @@ func (mr *MockInterfaceMockRecorder) Unprovision() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unprovision", reflect.TypeOf((*MockInterface)(nil).Unprovision))
 }
 
+// GetFlog mocks base method.
+func (m *MockInterface) GetFlog() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFlog")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // StopConfiguration mocks base method.
 func (m *MockInterface) StopConfiguration() (amt.StopConfigurationResponse, error) {
 	m.ctrl.T.Helper()
@@ -285,6 +294,12 @@ func (m *MockInterface) StopConfiguration() (amt.StopConfigurationResponse, erro
 	ret0, _ := ret[0].(amt.StopConfigurationResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
+}
+
+// GetFlog indicates an expected call of GetFlog.
+func (mr *MockInterfaceMockRecorder) GetFlog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlog", reflect.TypeOf((*MockInterface)(nil).GetFlog))
 }
 
 // StopConfiguration indicates an expected call of StopConfiguration.

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -88,6 +88,10 @@ func (c MockAMT) StartConfigurationHBased(amt.SecureHBasedParameters) (amt.Secur
 	return amt.SecureHBasedResponse{}, nil
 }
 
+func (c MockAMT) GetFlog() ([]byte, error) {
+	return []byte{}, nil
+}
+
 func (c MockAMT) StopConfiguration() (amt.StopConfigurationResponse, error) {
 	return amt.StopConfigurationResponse{}, nil
 }
@@ -374,6 +378,10 @@ func (c MockAMTInvalidUUID) GetUUID() (string, error) {
 	return "00000000-0000-0000-0000-000000000000", nil
 }
 
+func (c MockAMTInvalidUUID) GetFlog() ([]byte, error) {
+	return []byte{}, nil
+}
+
 func TestCreateMessageRequestWithInvalidUUID(t *testing.T) {
 	mockAMT := MockAMTInvalidUUID{}
 	payload := Payload{
@@ -391,6 +399,10 @@ type MockAMTInvalidUUIDPattern struct {
 
 func (c MockAMTInvalidUUIDPattern) GetUUID() (string, error) {
 	return "03000200-0400-0500-0006-000700080009", nil
+}
+
+func (c MockAMTInvalidUUIDPattern) GetFlog() ([]byte, error) {
+	return []byte{}, nil
 }
 
 func TestCreateMessageRequestWithInvalidUUIDPattern(t *testing.T) {

--- a/pkg/heci/types.go
+++ b/pkg/heci/types.go
@@ -7,6 +7,7 @@ package heci
 
 type Interface interface {
 	Init(useLME, useWD bool) error
+	InitHOTHAM() error
 	GetBufferSize() uint32
 	SendMessage(buffer []byte, done *uint32) (bytesWritten int, err error)
 	ReceiveMessage(buffer []byte, done *uint32) (bytesRead int, err error)

--- a/pkg/hotham/commands.go
+++ b/pkg/hotham/commands.go
@@ -1,0 +1,194 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package hotham
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/heci"
+	log "github.com/sirupsen/logrus"
+)
+
+type Command struct {
+	Heci heci.Interface
+}
+
+type Interface interface {
+	Open() error
+	Close()
+	Call(command []byte, commandSize int) (result []byte, err error)
+	GetFlogSize() (size uint32, err error)
+	GetFlog() (flogData []byte, err error)
+}
+
+func NewCommand() Command {
+	return Command{
+		Heci: heci.NewDriver(),
+	}
+}
+
+func (hotham Command) Open() error {
+	return hotham.Heci.InitHOTHAM()
+}
+
+func (hotham Command) Close() {
+	hotham.Heci.Close()
+}
+
+func (hotham Command) Call(command []byte, commandSize int) (result []byte, err error) {
+	if commandSize < 0 || uint64(commandSize) > math.MaxInt32 {
+		return nil, fmt.Errorf("buffer length exceeds uint32 maximum value")
+	}
+
+	// Send the actual command bytes
+	actualCommandSize := uint32(len(command))
+
+	bytesWritten, err := hotham.Heci.SendMessage(command, &actualCommandSize)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytesWritten != len(command) {
+		return nil, errors.New("failed to send complete message")
+	}
+
+	buffer := make([]byte, hotham.Heci.GetBufferSize())
+
+	// Receive up to the expected response size
+	// Add retry logic with small delays for HOTHAM interface
+	expectedResponseSize := uint32(commandSize)
+
+	var bytesRead int
+
+	maxRetries := 5
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			sleepTime := time.Duration(attempt*10) * time.Millisecond
+			time.Sleep(sleepTime)
+		}
+
+		bytesRead, err = hotham.Heci.ReceiveMessage(buffer, &expectedResponseSize)
+		if err != nil {
+			continue
+		}
+
+		if bytesRead > 0 {
+			break
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("after %d retries: %v", maxRetries, err)
+	}
+
+	if bytesRead <= 0 {
+		return nil, errors.New("empty response received")
+	}
+
+	return buffer[:bytesRead], nil
+}
+
+// GetFlogSize retrieves the size of the Flash Log
+// Returns total size of records in flash log
+// Uses 4-byte HOTHAM header through HOTHAM GUID connection
+func (hotham Command) GetFlogSize() (size uint32, err error) {
+	// Create request with 4-byte HOTHAM header
+	header := NewHOTHAMHeader(PCH_DFX_FLOG_GET_SIZE)
+	request := GetFlogSizeRequest{Header: header}
+
+	// Pack the HOTHAM header (4 bytes)
+	requestBytes := request.Header.Pack()
+
+	// Send request and receive response
+	// Expected response: 4 byte header + 2 byte uint16 size = 6 bytes
+	response, err := hotham.Call(requestBytes, 6)
+	if err != nil {
+		log.Errorf("GetFlogSize: HOTHAM Call failed: %v", err)
+
+		return 0, err
+	}
+
+	// Response should be at least 6 bytes (4 byte HOTHAM header + 2 byte size)
+	if len(response) < 6 {
+		log.Errorf("GetFlogSize: Invalid response size: got %d bytes, expected at least 6", len(response))
+
+		// Check if this is an error response
+		if len(response) == 4 {
+			log.Errorf("GetFlogSize: Got 4-byte response: %02x %02x %02x %02x",
+				response[0], response[1], response[2], response[3])
+
+			// Parse as HOTHAM header to extract error code
+			var respHeader HOTHAMHeader
+			respHeader.Unpack(response)
+			log.Errorf("GetFlogSize: Response - MsgClass=%d TargetId=%d SeqNo=%d ReqCode=0x%02x MsgLen=%d",
+				respHeader.MsgClass, respHeader.TargetId, respHeader.SequenceNo, respHeader.ReqCode, respHeader.MsgLength)
+
+			// Check for common error codes
+			if response[3] == 0x89 {
+				return 0, fmt.Errorf("FLOG command not supported (error 0x89)")
+			}
+		}
+
+		return 0, fmt.Errorf("invalid response size: got %d bytes, expected at least 6", len(response))
+	}
+
+	// Parse response: [Header(4 bytes)][Size(2 bytes as uint16)]
+	// Size is at bytes 4-5 (little-endian uint16)
+	flogSize := uint32(response[4]) | (uint32(response[5]) << 8)
+
+	log.Tracef("GetFlogSize: FLOG size = %d bytes (0x%x)", flogSize, flogSize)
+
+	return flogSize, nil
+}
+
+// GetFlog retrieves the Flash Log data
+// Returns flash log records (up to buffer size)
+// Uses 4-byte HOTHAM header through HOTHAM GUID connection
+func (hotham Command) GetFlog() (flogData []byte, err error) {
+	// Create request with 4-byte HOTHAM header
+	header := NewHOTHAMHeader(PCH_DFX_FLOG_GET_LOG)
+	request := GetFlogRequest{Header: header}
+
+	// Pack the HOTHAM header (4 bytes)
+	requestBytes := request.Header.Pack()
+
+	// Send request and receive response
+	// Expected response: 8196 bytes (4 byte header + 8192 byte data)
+	expectedSize := 8196
+
+	response, err := hotham.Call(requestBytes, expectedSize)
+	if err != nil {
+		log.Errorf("GetFlog: HOTHAM Call failed: %v", err)
+
+		return nil, err
+	}
+
+	// Parse response - skip header (4 bytes) and return data
+	if len(response) < 4 {
+		log.Errorf("GetFlog: Invalid response size: got %d bytes, expected at least 4", len(response))
+
+		return nil, fmt.Errorf("invalid response size: got %d bytes, expected at least 4", len(response))
+	}
+
+	// Parse response header to check for errors
+	var respHeader HOTHAMHeader
+	respHeader.Unpack(response)
+
+	// Check if response indicates success (MsgLength should contain data length)
+	if respHeader.MsgLength == 0 && len(response) == 4 {
+		log.Errorf("GetFlog: Got HOTHAM error response with no data")
+
+		return nil, fmt.Errorf("HOTHAM error: empty response")
+	}
+
+	// The flash log data starts after the 4-byte HOTHAM header
+	flogData = response[4:]
+
+	return flogData, nil
+}

--- a/pkg/hotham/types.go
+++ b/pkg/hotham/types.go
@@ -1,0 +1,122 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+// Package hotham implements CSME Flash Log (FLOG) retrieval commands.
+//
+// Implementation Details:
+// - Connects via HOTHAM GUID: {082EE5A7-7C25-470A-9643-0C06F0466EA1}
+// - Uses 4-byte HOTHAM_HECI_HEADER (bit-packed into 32 bits)
+// - Commands: GetFlogSize (0x80), GetFlog (0x81)
+
+package hotham
+
+import (
+	"encoding/binary"
+)
+
+// FLOG Protocol Constants
+const (
+	// Flash Log Commands (ReqCode values)
+	PCH_DFX_FLOG_GET_SIZE = 0x80 // GetFlogSize command
+	PCH_DFX_FLOG_GET_LOG  = 0x81 // GetFlog command
+
+	// HOTHAM Message Classes
+	HTM_MSG_CLASS_COMMAND = 2 // Command message class
+
+	// Target Silicon ID
+	HTM_TARGET_ID = 1 // Target Silicon ID
+
+	// FLOG response size
+	FLOG_DATA_SIZE = 8192 // Flash log data size (8196 - 4-byte header)
+)
+
+// HOTHAMHeader represents the HOTHAM HECI message header (4 bytes total)
+// This is a bit-packed structure used for CSME FLOG commands
+// The entire header is packed into 32 bits (4 bytes)
+type HOTHAMHeader struct {
+	MsgClass   uint8  // 2 bits: Message class (HTM_MSG_CLASS_COMMAND = 2)
+	TargetId   uint8  // 3 bits: Target Silicon ID (1)
+	SequenceNo uint8  // 3 bits: Sequence number (0)
+	ReqCode    uint8  // 8 bits: Request/Response opcode (0x80, 0x81)
+	MsgLength  uint16 // 12 bits: Message length (0 for requests)
+	Reserved   uint8  // 3 bits: Reserved (0)
+	HeaderType uint8  // 1 bit: Header type (0)
+}
+
+// Pack encodes the HOTHAM header into a 4-byte buffer
+// The HOTHAM_HECI_HEADER is bit-packed into 32 bits (4 bytes)
+func (h *HOTHAMHeader) Pack() []byte {
+	buf := make([]byte, 4)
+
+	// Pack first 32 bits: MsgClass(2) | TargetId(3) | SequenceNo(3) | ReqCode(8) | MsgLength(12) | Reserved(3) | HeaderType(1)
+	var header32 uint32
+
+	header32 |= uint32(h.MsgClass&0x3) << 0     // bits 0-1
+	header32 |= uint32(h.TargetId&0x7) << 2     // bits 2-4
+	header32 |= uint32(h.SequenceNo&0x7) << 5   // bits 5-7
+	header32 |= uint32(h.ReqCode&0xFF) << 8     // bits 8-15
+	header32 |= uint32(h.MsgLength&0xFFF) << 16 // bits 16-27
+	header32 |= uint32(h.Reserved&0x7) << 28    // bits 28-30
+	header32 |= uint32(h.HeaderType&0x1) << 31  // bit 31
+
+	// Write as little-endian (Intel architecture)
+	binary.LittleEndian.PutUint32(buf[0:4], header32)
+
+	return buf
+}
+
+// Unpack decodes a 4-byte buffer into the HOTHAM header
+func (h *HOTHAMHeader) Unpack(buf []byte) {
+	if len(buf) < 4 {
+		return
+	}
+
+	// Read first 32 bits
+	header32 := binary.LittleEndian.Uint32(buf[0:4])
+
+	// Extract bit fields
+	h.MsgClass = uint8((header32 >> 0) & 0x3)
+	h.TargetId = uint8((header32 >> 2) & 0x7)
+	h.SequenceNo = uint8((header32 >> 5) & 0x7)
+	h.ReqCode = uint8((header32 >> 8) & 0xFF)
+	h.MsgLength = uint16((header32 >> 16) & 0xFFF)
+	h.Reserved = uint8((header32 >> 28) & 0x7)
+	h.HeaderType = uint8((header32 >> 31) & 0x1)
+}
+
+// NewHOTHAMHeader creates a new HOTHAM header for FLOG commands
+func NewHOTHAMHeader(reqCode uint8) HOTHAMHeader {
+	return HOTHAMHeader{
+		MsgClass:   HTM_MSG_CLASS_COMMAND, // 2
+		TargetId:   HTM_TARGET_ID,         // 1
+		SequenceNo: 0,                     // 0
+		ReqCode:    reqCode,               // 0x80 or 0x81
+		MsgLength:  0,                     // 0 for requests
+		Reserved:   0,                     // 0
+		HeaderType: 0,                     // 0
+	}
+}
+
+// GetFlogSizeRequest requests the size of the Flash Log
+type GetFlogSizeRequest struct {
+	Header HOTHAMHeader
+}
+
+// GetFlogSizeResponse contains the Flash Log size
+type GetFlogSizeResponse struct {
+	Header HOTHAMHeader
+	Size   uint16 // Size in bytes
+}
+
+// GetFlogRequest requests the Flash Log data
+type GetFlogRequest struct {
+	Header HOTHAMHeader
+}
+
+// GetFlogResponse contains the Flash Log data
+type GetFlogResponse struct {
+	Header HOTHAMHeader
+	Data   []byte
+}

--- a/pkg/pthi/commands_test.go
+++ b/pkg/pthi/commands_test.go
@@ -33,6 +33,11 @@ func (c *MockHECICommands) Init(useLME, useWD bool) error {
 
 	return mockInitErr
 }
+
+func (c *MockHECICommands) InitHOTHAM() error {
+	return mockInitErr
+}
+
 func (c *MockHECICommands) GetBufferSize() uint32 { return 5120 } // MaxMessageLength
 
 func (c *MockHECICommands) SendMessage(buffer []byte, done *uint32) (bytesWritten int, err error) {


### PR DESCRIPTION
Implement rpc flog command to retrieve CSME Flash Log via HOTHAM HECI interface and save to file.
Add support for retrieving CSME Flash Log (FLOG) data through HOTHAM protocol.
FLOG contains firmware crash dumps and error records for debugging purposes.
Uses 4-byte bit-packed HOTHAM_HECI_HEADER structure.
- Add HOTHAM protocol support with 4-byte header format (types.go)
- Implement GetFlogSize() and GetFlog() commands (commands.go)
- Add HOTHAM GUID connection (082EE5A7-7C25-470A-9643-0C06F0466EA1)
- Add 'flog' subcommand under 'diagnostics csme' with --output flag
- Add retry logic for MEI response handling
- Add comprehensive error detection and logging

Resolves #1004