### PR TITLE
refactor: Add CIRA log retrieval command

### DIFF
--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
 )
 
 func TestLocalActivateCmd_Validate(t *testing.T) {
@@ -349,6 +350,10 @@ func (m *MockAMTCommand) StopConfiguration() (amt.StopConfigurationResponse, err
 	}
 
 	return amt.StopConfigurationResponse{Status: "Success"}, nil
+}
+
+func (m *MockAMTCommand) GetCiraLog() (pthi.GetCiraLogResponse, error) {
+	return pthi.GetCiraLogResponse{}, nil
 }
 
 func TestLocalActivationService_validateAMTState(t *testing.T) {

--- a/internal/commands/diagnostics/cira.go
+++ b/internal/commands/diagnostics/cira.go
@@ -6,15 +6,554 @@
 package diagnostics
 
 import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"text/template"
+	"time"
+
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
+)
+
+const (
+	unknownValue = "Unknown"
+	zeroIP       = "0.0.0.0"
 )
 
 // CIRACmd dumps CIRA-related firmware diagnostics.
 type CIRACmd struct {
 	DiagnosticsBaseCmd
+
+	Output string `help:"Output file path for the CIRA log text data" short:"o"`
 }
 
 // Run executes the CIRA diagnostics command.
 func (cmd *CIRACmd) Run(ctx *commands.Context) error {
+	// Generate default filename if not provided
+	if cmd.Output == "" {
+		timestamp := time.Now().Format("20060102_150405")
+		cmd.Output = fmt.Sprintf("%s_ciralog.txt", timestamp)
+	}
+
+	// Ensure output directory exists
+	outputDir := filepath.Dir(cmd.Output)
+	if outputDir != "." && outputDir != "" {
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
+	}
+
+	// Get CIRA log from firmware
+	result, err := ctx.AMTCommand.GetCiraLog()
+	if err != nil {
+		return err
+	}
+
+	// Create output file
+	file, err := os.Create(cmd.Output)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer file.Close()
+
+	// Write CIRA log data to file
+	outputCiraLogText(file, result)
+
+	fmt.Printf("CIRA Log successfully retrieved\nOutput file: %s\n", cmd.Output)
+
 	return nil
+}
+
+func outputCiraLogText(w io.Writer, result pthi.GetCiraLogResponse) {
+	t := template.New("ciraLog").Funcs(template.FuncMap{
+		"getConnectionStateString":      getConnectionStateString,
+		"formatTimestamp":               formatTimestamp,
+		"getLastConnectionStatusString": getLastConnectionStatusString,
+		"getLastTunnelStatusString":     getLastTunnelStatusString,
+		"getConnectionTriggerString":    getConnectionTriggerString,
+		"byteArrayToString":             byteArrayToString,
+		"getAuthenticationMethodString": getAuthenticationMethodString,
+		"getInterfaceTypeString":        getInterfaceTypeString,
+		"getHostControlString":          getHostControlString,
+		"getLinkStatusString":           getLinkStatusString,
+		"getDhcpModeString":             getDhcpModeString,
+		"formatIPv4":                    formatIPv4,
+		"formatIPv6":                    formatIPv6,
+		"getIPv6AddressTypeString":      getIPv6AddressTypeString,
+		"getIPv6AddressStateString":     getIPv6AddressStateString,
+		"getConnectionStatusString":     getConnectionStatusString,
+		"getTcpFailureCodeString":       getTcpFailureCodeString,
+		"getTlsFailureCodeString":       getTlsFailureCodeString,
+		"getClosedByString":             getClosedByString,
+		"getAPFDisconnectReasonString":  getAPFDisconnectReasonString,
+		"getClosureReasonString":        getClosureReasonString,
+		"getTunnelStatusString": func(opened uint8) string {
+			if opened == 1 {
+				return "Opened"
+			}
+
+			return "Closed"
+		},
+	})
+
+	t, err := t.Parse(ciraLogTemplate)
+	if err != nil {
+		fmt.Fprintf(w, "Error parsing template: %v\n", err)
+
+		return
+	}
+
+	err = t.Execute(w, result)
+	if err != nil {
+		fmt.Fprintf(w, "Error executing template: %v\n", err)
+	}
+}
+
+const ciraLogTemplate = `Status = {{printf "%d" .Header.Status}} ({{.Header.Status}})
+Version = {{.Version}}
+CiraStatusSummary:
+	IsTunnelOpened = {{.CiraStatusSummary.IsTunnelOpened}} ({{getTunnelStatusString .CiraStatusSummary.IsTunnelOpened}})
+	CurrentConnectionState = {{.CiraStatusSummary.CurrentConnectionState}} ({{getConnectionStateString .CiraStatusSummary.CurrentConnectionState}})
+	LastKeepAlive(The time in which the last keepalive message was sent, 0 if not currently connected) = {{.CiraStatusSummary.LastKeepAlive}}({{.CiraStatusSummary.LastKeepAlive | formatTimestamp}})
+	KeepAliveInterval(AMT's keepalive interval in seconds, valid only if currently connected) = {{.CiraStatusSummary.KeepAliveInterval}}
+	LastConnectionStatus = {{.CiraStatusSummary.LastConnectionStatus}} ({{getLastConnectionStatusString .CiraStatusSummary.LastConnectionStatus}})
+	LastConnectionTimestamp = {{.CiraStatusSummary.LastConnectionTimestamp}} ({{.CiraStatusSummary.LastConnectionTimestamp | formatTimestamp}})
+	LastTunnelStatus = {{.CiraStatusSummary.LastTunnelStatus}} ({{getLastTunnelStatusString .CiraStatusSummary.LastTunnelStatus}})
+	LastTunnelOpenedTimestamp = {{.CiraStatusSummary.LastTunnelOpenedTimestamp}} ({{.CiraStatusSummary.LastTunnelOpenedTimestamp | formatTimestamp}})
+	LastTunnelClosedTimestamp = {{.CiraStatusSummary.LastTunnelClosedTimestamp}} ({{.CiraStatusSummary.LastTunnelClosedTimestamp | formatTimestamp}})
+LastFailedTunnelLogEntry:
+	Valid = {{.LastFailedTunnelLogEntry.Valid}}
+	OpenTimestamp = {{.LastFailedTunnelLogEntry.OpenTimestamp}} ({{.LastFailedTunnelLogEntry.OpenTimestamp | formatTimestamp}})
+	RemoteAccessConnectionTrigger = {{.LastFailedTunnelLogEntry.RemoteAccessConnectionTrigger}} ({{getConnectionTriggerString .LastFailedTunnelLogEntry.RemoteAccessConnectionTrigger}})
+	MpsHostname = {{byteArrayToString .LastFailedTunnelLogEntry.MpsHostname}}
+	ProxyUsed(Indicates whether CIRA connection is over proxy) = {{.LastFailedTunnelLogEntry.ProxyUsed}}
+	ProxyName = {{byteArrayToString .LastFailedTunnelLogEntry.ProxyName}}
+	AuthenticationMethod = {{.LastFailedTunnelLogEntry.AuthenticationMethod}} ({{getAuthenticationMethodString .LastFailedTunnelLogEntry.AuthenticationMethod}})
+	ConnectedInterface = {{.LastFailedTunnelLogEntry.ConnectedInterface}} ({{getInterfaceTypeString .LastFailedTunnelLogEntry.ConnectedInterface}})
+	LastKeepAlive = {{.LastFailedTunnelLogEntry.LastKeepAlive}} ({{.LastFailedTunnelLogEntry.LastKeepAlive | formatTimestamp}})
+	KeepAliveInterval = {{.LastFailedTunnelLogEntry.KeepAliveInterval}}
+	TunnelClosureInfo:
+		ClosureTimestamp = {{.LastFailedTunnelLogEntry.TunnelClosureInfo.ClosureTimestamp}} ({{.LastFailedTunnelLogEntry.TunnelClosureInfo.ClosureTimestamp | formatTimestamp}})
+		ClosedBy = {{.LastFailedTunnelLogEntry.TunnelClosureInfo.ClosedByMps}} ({{getClosedByString .LastFailedTunnelLogEntry.TunnelClosureInfo.ClosedByMps}})
+		APF_DISCONNECT_REASON = {{.LastFailedTunnelLogEntry.TunnelClosureInfo.APF_DISCONNECT_REASON}} ({{getAPFDisconnectReasonString .LastFailedTunnelLogEntry.TunnelClosureInfo.APF_DISCONNECT_REASON}})
+		ClosureReason = {{.LastFailedTunnelLogEntry.TunnelClosureInfo.ClosureReason}} ({{getClosureReasonString .LastFailedTunnelLogEntry.TunnelClosureInfo.ClosureReason}})
+FailedConnectionLogEntry:
+	Valid = {{.FailedConnectionLogEntry.Valid}}
+	OpenTimestamp = {{.FailedConnectionLogEntry.OpenTimestamp}} ({{.FailedConnectionLogEntry.OpenTimestamp | formatTimestamp}})
+	RemoteAccessConnectionTrigger = {{.FailedConnectionLogEntry.RemoteAccessConnectionTrigger}} ({{getConnectionTriggerString .FailedConnectionLogEntry.RemoteAccessConnectionTrigger}})
+	MpsHostname = {{byteArrayToString .FailedConnectionLogEntry.MpsHostname}}
+	AuthenticationMethod = {{.FailedConnectionLogEntry.AuthenticationMethod}} ({{getAuthenticationMethodString .FailedConnectionLogEntry.AuthenticationMethod}})
+	InterfaceData:
+{{- range $i, $e := .FailedConnectionLogEntry.InterfaceData}}
+		{{if eq $i 0}}Lan Item:{{else}}Wireless Item:{{end}}
+			InterfacePresent = {{$e.InterfacePresent}}
+			LinkStatus = {{$e.LinkStatus}} ({{getLinkStatusString $e.LinkStatus}})
+			IPParameters:
+				DhcpMode = {{$e.IPParameters.DhcpMode}} ({{getDhcpModeString $e.IPParameters.DhcpMode}})
+				IpAddress = {{formatIPv4 $e.IPParameters.IpAddress}}
+				DefaultGatewayAddress = {{formatIPv4 $e.IPParameters.DefaultGatewayAddress}}
+				PrimaryDnsAddress = {{formatIPv4 $e.IPParameters.PrimaryDnsAddress}}
+				SecondaryDnsAddress = {{formatIPv4 $e.IPParameters.SecondaryDnsAddress}}
+				DomainName = {{byteArrayToString $e.IPParameters.DomainName}}
+				IPv6DefaultRouter:
+					Address = {{formatIPv6 $e.IPParameters.IPv6DefaultRouter}}
+				PrimaryDNS:
+					Address = {{formatIPv6 $e.IPParameters.PrimaryDNS}}
+				SecondaryDNS:
+					Address = {{formatIPv6 $e.IPParameters.SecondaryDNS}}
+				IPv6Addresses:
+{{- range $j, $addr := $e.IPParameters.IPv6Addresses}}
+					Address = {{formatIPv6 $addr.Address}}
+					Type = {{$addr.Type}} ({{getIPv6AddressTypeString $addr.Type}})
+					State = {{$addr.State}} ({{getIPv6AddressStateString $addr.State}})
+{{- end}}
+{{- end}}
+	WirelessAdditionalData:
+		ProfileName = {{byteArrayToString .FailedConnectionLogEntry.WirelessAdditionalData.ProfileName}}
+		HostControl = {{.FailedConnectionLogEntry.WirelessAdditionalData.HostControl}} ({{getHostControlString .FailedConnectionLogEntry.WirelessAdditionalData.HostControl}})
+	WiredAdditionalData:
+		802.1xAuthenticationResult = {{.FailedConnectionLogEntry.WiredAdditionalData.AuthResult802_1x}}
+		802.1xAuthenticationSubResult = {{.FailedConnectionLogEntry.WiredAdditionalData.AuthSubResult802_1x}}
+		WiredMediaType = {{.FailedConnectionLogEntry.WiredAdditionalData.WiredMediaType}}
+		DiscreteLanStatus = {{.FailedConnectionLogEntry.WiredAdditionalData.DiscreteLanStatus}}
+	ConnectedInterface = {{.FailedConnectionLogEntry.ConnectedInterface}} ({{getInterfaceTypeString .FailedConnectionLogEntry.ConnectedInterface}})
+	ConnectionDetails:
+{{- range $i, $e := .FailedConnectionLogEntry.ConnectionDetails}}
+		{{if eq $i 0}}Lan Item:{{else}}Wireless Item:{{end}}
+			ConnectionStatus = {{$e.ConnectionStatus}} ({{getConnectionStatusString $e.ConnectionStatus}})
+			ProxyUsed = {{$e.ProxyUsed}}
+			ProxyName = {{byteArrayToString $e.ProxyName}}
+			TcpFailureCode = {{$e.TcpFailureCode}} ({{getTcpFailureCodeString $e.TcpFailureCode}})
+			TlsFailureCode = {{$e.TlsFailureCode}} ({{getTlsFailureCodeString $e.TlsFailureCode}})
+{{- end}}
+	TunnelEstablishmentFailure:
+		ClosureTimestamp = {{.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureTimestamp}} ({{.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureTimestamp | formatTimestamp}})
+		ClosedBy = {{.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosedByMps}} ({{getClosedByString .FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosedByMps}})
+		APF_DISCONNECT_REASON = {{.FailedConnectionLogEntry.TunnelEstablishmentFailure.APF_DISCONNECT_REASON}} ({{getAPFDisconnectReasonString .FailedConnectionLogEntry.TunnelEstablishmentFailure.APF_DISCONNECT_REASON}})
+		ClosureReason = {{.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureReason}} ({{getClosureReasonString .FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureReason}})
+`
+
+// Helper functions
+func byteArrayToString(data interface{}) string {
+	var bytes []byte
+
+	switch v := data.(type) {
+	case [256]uint8:
+		bytes = v[:]
+	case [192]uint8:
+		bytes = v[:]
+	case [33]uint8:
+		bytes = v[:]
+	case []uint8:
+		bytes = v
+	default:
+		return ""
+	}
+
+	// Find null terminator
+	for i, b := range bytes {
+		if b == 0 {
+			return string(bytes[:i])
+		}
+	}
+
+	// No null terminator found, return entire array
+	return string(bytes)
+}
+
+func formatTimestamp(ts uint32) string {
+	if ts == 0 {
+		return "1970-01-01 00:00:00 UTC"
+	}
+
+	t := time.Unix(int64(ts), 0).UTC()
+
+	return t.Format("2006-01-02 15:04:05") + " UTC"
+}
+
+func formatIPv4(ip uint32) string {
+	if ip == 0 {
+		return zeroIP
+	}
+
+	return net.IP([]byte{
+		byte(ip),
+		byte(ip >> 8),
+		byte(ip >> 16),
+		byte(ip >> 24),
+	}).String()
+}
+
+func formatIPv6(addr pthi.IPv6Address) string {
+	// Check if all bytes are zero
+	allZero := true
+
+	for _, b := range addr.Address {
+		if b != 0 {
+			allZero = false
+
+			break
+		}
+	}
+
+	if allZero {
+		return ""
+	}
+
+	ip := net.IP(addr.Address[:])
+
+	return ip.String()
+}
+
+var (
+	connectionStates = map[uint8]string{
+		0: "Inside Enterprise",
+		1: "Inside Corporate Environment, outside Enterprise",
+		2: "Outside Enterprise",
+	}
+
+	connectionTriggers = map[uint8]string{
+		0: "User Initiated",
+		1: "Alert",
+		2: "Periodic",
+	}
+
+	interfaceTypes = map[uint8]string{
+		0: "INTERFACE_TYPE_WIRED",
+		1: "INTERFACE_TYPE_WIRELESS",
+		2: "INTERFACE_TYPE_NONE",
+	}
+
+	dhcpModes = map[uint8]string{
+		0: "None",
+		1: "Disabled",
+		2: "Enabled",
+	}
+
+	authMethods = map[uint8]string{
+		1: "MutualTLS",
+		2: "Username and password",
+	}
+
+	ipv6AddressTypes = map[uint8]string{
+		0: "CFG_Ipv6_ADDR_TYPE_LINK_LOCAL",
+		1: "CFG_Ipv6_ADDR_TYPE_GLOBAL",
+		2: "CFG_Ipv6_ADDR_TYPE_STATELESS",
+		3: "CFG_Ipv6_ADDR_TYPE_STATEFUL",
+	}
+
+	ipv6AddressStates = map[uint8]string{
+		0: "CFG_Ipv6_ADDR_STATE_TENTATIVE",
+		1: "CFG_Ipv6_ADDR_STATE_PREFERRED",
+		2: "CFG_Ipv6_ADDR_STATE_DEPRECATED",
+	}
+
+	connectionStatuses = map[uint32]string{
+		0: "CIRA_LOG_CONNECTION_STATUS_NA",
+		1: "CIRA_LOG_CONNECTION_STATUS_INTERNAL_ERROR",
+		2: "CIRA_LOG_CONNECTION_STATUS_ERROR_DNS",
+		3: "CIRA_LOG_CONNECTION_STATUS_ERROR_TCP",
+		4: "CIRA_LOG_CONNECTION_STATUS_ERROR_TLS",
+		5: "CIRA_LOG_CONNECTION_STATUS_SUCCESS",
+		6: "CIRA_LOG_CONNECTION_STATUS_IN_PROGRESS",
+	}
+
+	tcpFailureCodes = map[uint32]string{
+		0: "CIRA_LOGGER_TCP_ERR_SUCCESS",
+		1: "CIRA_LOGGER_TCP_ERR_GENERAL_FAILURE",
+		2: "CIRA_LOGGER_TCP_ERR_TIMED_OUT",
+		3: "CIRA_LOGGER_TCP_ERR_CONNECTION_RESET",
+		4: "CIRA_LOGGER_TCP_ERR_DESTINATION_UNREACHABLE",
+	}
+
+	apfDisconnectReasons = map[uint8]string{
+		0:  "APF_DISCONNECT_INVALID_REASON_CODE",
+		1:  "APF_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT",
+		2:  "APF_DISCONNECT_PROTOCOL_ERROR",
+		3:  "APF_DISCONNECT_KEY_EXCHANGE_FAILED",
+		4:  "APF_DISCONNECT_RESERVED",
+		5:  "APF_DISCONNECT_MAC_ERROR",
+		6:  "APF_DISCONNECT_COMPRESSION_ERROR",
+		7:  "APF_DISCONNECT_SERVICE_NOT_AVAILABLE",
+		8:  "APF_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED",
+		9:  "APF_DISCONNECT_HOST_KEY_NOT_VERIFIABLE",
+		10: "APF_DISCONNECT_CONNECTION_LOST",
+		11: "APF_DISCONNECT_BY_APPLICATION",
+		12: "APF_DISCONNECT_TOO_MANY_CONNECTIONS",
+		13: "APF_DISCONNECT_AUTH_CANCELED_BY_USER",
+		14: "APF_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE",
+		15: "APF_DISCONNECT_ILLEGAL_USER_NAME",
+		16: "APF_DISCONNECT_CONNECTION_TIMED_OUT",
+	}
+
+	closureReasons = map[uint8]string{
+		0:    "AMT_CLOSE_REASON_USER_INITIATE_REQUEST",
+		1:    "AMT_CLOSE_REASON_TUNNEL_TIMER_EXPIRED",
+		2:    "AMT_CLOSE_REASON_INTERNAL_ERROR",
+		3:    "AMT_CLOSE_REASON_KEEP_ALIVE_EXPIRED",
+		4:    "AMT_CLOSE_REASON_TCP_SOCKET_ERROR",
+		5:    "AMT_CLOSE_REASON_INVALID_APF_COMMAND",
+		0xFF: "AMT_CLOSE_REASON_NA",
+	}
+
+	hostControls = map[uint8]string{
+		0: "AMT",
+		1: "Host",
+	}
+
+	closedByEntities = map[uint8]string{
+		0: "AMT",
+		1: "MPS",
+	}
+
+	linkStatuses = map[uint8]string{
+		0: "Down",
+		1: "Up",
+	}
+
+	tlsFailureCodes = map[int32]string{
+		0:   "close_notify",
+		10:  "unexpected_message",
+		20:  "bad_record_mac",
+		21:  "decryption_failed_RESERVED",
+		22:  "record_overflow",
+		30:  "decompression_failure_RESERVED",
+		40:  "handshake_failure",
+		41:  "no_certificate_RESERVED",
+		42:  "bad_certificate",
+		43:  "unsupported_certificate",
+		44:  "certificate_revoked",
+		45:  "certificate_expired",
+		46:  "certificate_unknown",
+		47:  "illegal_parameter",
+		48:  "unknown_ca",
+		49:  "access_denied",
+		50:  "decode_error",
+		51:  "decrypt_error",
+		60:  "export_restriction_RESERVED",
+		70:  "protocol_version",
+		71:  "insufficient_security",
+		80:  "internal_error",
+		86:  "inappropriate_fallback",
+		90:  "user_canceled",
+		100: "no_renegotiation_RESERVED",
+		109: "missing_extension",
+		110: "unsupported_extension",
+		111: "certificate_unobtainable_RESERVED",
+		112: "unrecognized_name",
+		113: "bad_certificate_status_response",
+		114: "bad_certificate_hash_value_RESERVED",
+		115: "unknown_psk_identity",
+		116: "certificate_required",
+		120: "no_application_protocol",
+	}
+
+	lastConnectionStatuses = map[uint8]string{
+		0: "Connection established successfully",
+		1: "Failed to connect",
+	}
+
+	lastTunnelStatuses = map[uint8]string{
+		0: "Session opened and closed successfully",
+		1: "Session failed due to an error",
+	}
+)
+
+func getConnectionStateString(state uint8) string {
+	if val, ok := connectionStates[state]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getConnectionTriggerString(trigger uint8) string {
+	if val, ok := connectionTriggers[trigger]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getInterfaceTypeString(iface uint8) string {
+	if val, ok := interfaceTypes[iface]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getDhcpModeString(mode uint8) string {
+	if val, ok := dhcpModes[mode]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getAuthenticationMethodString(method uint8) string {
+	if val, ok := authMethods[method]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getIPv6AddressTypeString(addrType uint8) string {
+	if val, ok := ipv6AddressTypes[addrType]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getIPv6AddressStateString(state uint8) string {
+	if val, ok := ipv6AddressStates[state]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getConnectionStatusString(status uint32) string {
+	if val, ok := connectionStatuses[status]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getTcpFailureCodeString(code uint32) string {
+	if val, ok := tcpFailureCodes[code]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getAPFDisconnectReasonString(reason uint8) string {
+	if val, ok := apfDisconnectReasons[reason]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getClosureReasonString(reason uint8) string {
+	if val, ok := closureReasons[reason]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getHostControlString(control uint8) string {
+	if val, ok := hostControls[control]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getClosedByString(closedBy uint8) string {
+	if val, ok := closedByEntities[closedBy]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getLinkStatusString(status uint8) string {
+	if val, ok := linkStatuses[status]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getTlsFailureCodeString(code int32) string {
+	if val, ok := tlsFailureCodes[code]; ok {
+		return val
+	}
+
+	return fmt.Sprintf("unknown_alert_%d", code)
+}
+
+func getLastConnectionStatusString(status uint8) string {
+	if val, ok := lastConnectionStatuses[status]; ok {
+		return val
+	}
+
+	return unknownValue
+}
+
+func getLastTunnelStatusString(status uint8) string {
+	if val, ok := lastTunnelStatuses[status]; ok {
+		return val
+	}
+
+	return unknownValue
 }

--- a/internal/commands/diagnostics/cira_test.go
+++ b/internal/commands/diagnostics/cira_test.go
@@ -1,0 +1,320 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ *********************************************************************/
+
+package diagnostics
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCIRACommand_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a temporary directory for test output
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_cira.txt")
+
+	// Mock CIRA log data with valid response
+	mockCiraResponse := pthi.GetCiraLogResponse{
+		Header:  pthi.ResponseMessageHeader{},
+		Version: 1,
+		CiraStatusSummary: pthi.CIRAStatusSummary{
+			IsTunnelOpened:         1,
+			CurrentConnectionState: 2,
+		},
+	}
+
+	// Setup mock
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockAMT.EXPECT().GetCiraLog().Return(mockCiraResponse, nil)
+
+	// Create command
+	cmd := CIRACmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, outputFile)
+
+	// Verify file contains expected content
+	fileData, err := os.ReadFile(outputFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(fileData), "Status = 0")
+	assert.Contains(t, string(fileData), "Version = 1")
+}
+
+func TestCIRACommand_JSONOutput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a temporary directory for test output
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_cira_json.txt")
+
+	// Mock CIRA log data
+	mockCiraResponse := pthi.GetCiraLogResponse{
+		Header:  pthi.ResponseMessageHeader{},
+		Version: 1,
+		CiraStatusSummary: pthi.CIRAStatusSummary{
+			IsTunnelOpened:         1,
+			CurrentConnectionState: 2,
+		},
+	}
+
+	// Setup mock
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockAMT.EXPECT().GetCiraLog().Return(mockCiraResponse, nil)
+
+	// Create command
+	cmd := CIRACmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, outputFile)
+}
+
+func TestCIRACommand_GetCiraLogError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a temporary directory for test output (even though error occurs before writing)
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_cira_error.txt")
+
+	// Setup mock to return error
+	mockAMT := mock.NewMockInterface(ctrl)
+	expectedErr := errors.New("failed to retrieve CIRA log")
+	mockAMT.EXPECT().GetCiraLog().Return(pthi.GetCiraLogResponse{}, expectedErr)
+
+	// Create command
+	cmd := CIRACmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command - should return error
+	err := cmd.Run(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve CIRA log")
+}
+
+func TestCIRACommand_EmptyResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a temporary directory for test output
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_cira_empty.txt")
+
+	// Mock empty CIRA log response
+	mockCiraResponse := pthi.GetCiraLogResponse{}
+
+	// Setup mock
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockAMT.EXPECT().GetCiraLog().Return(mockCiraResponse, nil)
+
+	// Create command
+	cmd := CIRACmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command - should handle empty response
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	assert.FileExists(t, outputFile)
+}
+
+func TestCIRACommand_BinaryParsingValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create a temporary directory for test output
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "test_cira_parsing.txt")
+
+	// Mock CIRA log response with realistic parsed data
+	mockCiraResponse := pthi.GetCiraLogResponse{
+		Header: pthi.ResponseMessageHeader{
+			Header: pthi.MessageHeader{
+				Version:  pthi.Version{MajorNumber: 1, MinorNumber: 0},
+				Reserved: 0,
+				Command:  pthi.CommandFormat{Val: 0x0400008e},
+				Length:   2785,
+			},
+			Status: 0,
+		},
+		Version: 0,
+		CiraStatusSummary: pthi.CIRAStatusSummary{
+			IsTunnelOpened:            0,
+			CurrentConnectionState:    2,
+			LastKeepAlive:             0,
+			KeepAliveInterval:         0,
+			LastConnectionStatus:      1,
+			LastConnectionTimestamp:   1770811569,
+			LastTunnelStatus:          1,
+			LastTunnelOpenedTimestamp: 1770211104,
+			LastTunnelClosedTimestamp: 1770317849,
+		},
+		LastFailedTunnelLogEntry: pthi.CIRATunnelLogEntry{
+			Valid:                         1,
+			OpenTimestamp:                 1770211104,
+			RemoteAccessConnectionTrigger: 2,
+			MpsHostname:                   [256]uint8{'m', 'p', 's', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'},
+			ProxyUsed:                     0,
+			AuthenticationMethod:          1,
+			ConnectedInterface:            1,
+			LastKeepAlive:                 1770296249,
+			KeepAliveInterval:             21600,
+			TunnelClosureInfo: pthi.TunnelClosureInfo{
+				ClosureTimestamp:      1770317849,
+				ClosedByMps:           0,
+				APF_DISCONNECT_REASON: 16,
+				ClosureReason:         3,
+			},
+		},
+		FailedConnectionLogEntry: pthi.CIRAFailedConnectionLogEntry{
+			Valid:                         1,
+			OpenTimestamp:                 1770811569,
+			RemoteAccessConnectionTrigger: 2,
+			MpsHostname:                   [256]uint8{'m', 'p', 's', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'},
+			AuthenticationMethod:          1,
+			WirelessAdditionalData: pthi.WirelessAdditionalData{
+				ProfileName: [33]byte{'W', 'I', 'F', 'I', '_', 'P', 'R', 'O', 'F', 'I', 'L', 'E', '_', '1'},
+				HostControl: 1,
+			},
+			ConnectedInterface: 2, // INTERFACE_TYPE_NONE
+			ConnectionDetails: [2]pthi.ConnectionDetail{
+				{
+					ConnectionStatus: 2, // DNS error - validated as uint32 (4 bytes)
+					ProxyUsed:        0,
+					TcpFailureCode:   0, // Validated as uint32 (4 bytes)
+					TlsFailureCode:   0, // Validated as int32 (4 bytes)
+				},
+				{
+					ConnectionStatus: 2, // DNS error - validated as uint32 (4 bytes)
+					ProxyUsed:        0,
+					TcpFailureCode:   0, // Validated as uint32 (4 bytes)
+					TlsFailureCode:   0, // Validated as int32 (4 bytes)
+				},
+			},
+			TunnelEstablishmentFailure: pthi.TunnelClosureInfo{
+				ClosureTimestamp:      0, // Validates correct offset after ConnectionDetails array
+				ClosedByMps:           0,
+				APF_DISCONNECT_REASON: 0,
+				ClosureReason:         0,
+			},
+		},
+	}
+
+	// Setup mock
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockAMT.EXPECT().GetCiraLog().Return(mockCiraResponse, nil)
+
+	// Create command
+	cmd := CIRACmd{
+		Output: outputFile,
+	}
+
+	// Create context
+	ctx := &commands.Context{
+		AMTCommand: mockAMT,
+	}
+
+	// Execute command
+	err := cmd.Run(ctx)
+	assert.NoError(t, err)
+
+	// Validate parsed response structure
+	assert.Equal(t, uint8(0), mockCiraResponse.Version, "Version should be 0")
+	assert.Equal(t, uint8(0), mockCiraResponse.CiraStatusSummary.IsTunnelOpened, "Tunnel should be closed")
+	assert.Equal(t, uint8(2), mockCiraResponse.CiraStatusSummary.CurrentConnectionState, "Should be Outside Enterprise")
+	assert.Equal(t, uint8(1), mockCiraResponse.CiraStatusSummary.LastConnectionStatus, "Last connection should have failed")
+	assert.Equal(t, uint8(1), mockCiraResponse.CiraStatusSummary.LastTunnelStatus, "Last tunnel should have failed")
+
+	// Validate LastFailedTunnelLogEntry fields
+	assert.Equal(t, uint8(1), mockCiraResponse.LastFailedTunnelLogEntry.Valid, "Entry should be valid")
+	assert.Equal(t, uint32(1770211104), mockCiraResponse.LastFailedTunnelLogEntry.OpenTimestamp, "OpenTimestamp should match")
+	assert.Equal(t, uint8(2), mockCiraResponse.LastFailedTunnelLogEntry.RemoteAccessConnectionTrigger, "Should be Periodic trigger")
+	assert.Equal(t, uint8(1), mockCiraResponse.LastFailedTunnelLogEntry.AuthenticationMethod, "Should be MutualTLS")
+	assert.Equal(t, uint8(1), mockCiraResponse.LastFailedTunnelLogEntry.ConnectedInterface, "Should be WIRELESS")
+	assert.Equal(t, uint32(1770317849), mockCiraResponse.LastFailedTunnelLogEntry.TunnelClosureInfo.ClosureTimestamp, "Tunnel closure timestamp should match")
+
+	// Validate FailedConnectionLogEntry fields
+	assert.Equal(t, uint8(1), mockCiraResponse.FailedConnectionLogEntry.Valid, "Entry should be valid")
+	assert.Equal(t, uint8(1), mockCiraResponse.FailedConnectionLogEntry.AuthenticationMethod, "Should be MutualTLS")
+	assert.Equal(t, uint8(2), mockCiraResponse.FailedConnectionLogEntry.ConnectedInterface, "Should be NONE")
+
+	// Validate ConnectionDetails array entries
+	assert.Equal(t, uint32(2), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[0].ConnectionStatus, "ConnectionStatus should be uint32")
+	assert.Equal(t, uint32(0), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[0].TcpFailureCode, "TcpFailureCode should be uint32")
+	assert.Equal(t, int32(0), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[0].TlsFailureCode, "TlsFailureCode should be int32")
+
+	assert.Equal(t, uint32(2), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[1].ConnectionStatus, "ConnectionStatus should be uint32")
+	assert.Equal(t, uint32(0), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[1].TcpFailureCode, "TcpFailureCode should be uint32")
+	assert.Equal(t, int32(0), mockCiraResponse.FailedConnectionLogEntry.ConnectionDetails[1].TlsFailureCode, "TlsFailureCode should be int32")
+
+	// Validate TunnelEstablishmentFailure fields
+	assert.Equal(t, uint32(0), mockCiraResponse.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureTimestamp, "ClosureTimestamp should be 0")
+	assert.Equal(t, uint8(0), mockCiraResponse.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosedByMps, "ClosedBy should be AMT")
+	assert.Equal(t, uint8(0), mockCiraResponse.FailedConnectionLogEntry.TunnelEstablishmentFailure.APF_DISCONNECT_REASON, "APF disconnect should be INVALID")
+	assert.Equal(t, uint8(0), mockCiraResponse.FailedConnectionLogEntry.TunnelEstablishmentFailure.ClosureReason, "Closure reason should be USER_INITIATE")
+
+	// Validate string field parsing
+	mpsHostname := string(mockCiraResponse.FailedConnectionLogEntry.MpsHostname[:15])
+	assert.Equal(t, "mps.example.com", mpsHostname, "MPS hostname should be parsed correctly")
+
+	profileName := string(mockCiraResponse.FailedConnectionLogEntry.WirelessAdditionalData.ProfileName[:14])
+	assert.Equal(t, "WIFI_PROFILE_1", profileName, "Wireless profile name should be parsed correctly")
+
+	// Verify file was created and contains expected content
+	assert.FileExists(t, outputFile)
+	fileData, err := os.ReadFile(outputFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(fileData), "Status = 0")
+	assert.Contains(t, string(fileData), "ClosureTimestamp = 0")
+	assert.Contains(t, string(fileData), "ConnectionStatus = 2")
+	assert.Contains(t, string(fileData), "mps.example.com")
+	assert.Contains(t, string(fileData), "WIFI_PROFILE_1")
+}

--- a/internal/mocks/amt_mock.go
+++ b/internal/mocks/amt_mock.go
@@ -14,6 +14,7 @@ import (
 	time "time"
 
 	amt "github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	pthi "github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -97,6 +98,21 @@ func (m *MockInterface) GetChangeEnabled() (amt.ChangeEnabledResponse, error) {
 func (mr *MockInterfaceMockRecorder) GetChangeEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChangeEnabled", reflect.TypeOf((*MockInterface)(nil).GetChangeEnabled))
+}
+
+// GetCiraLog mocks base method.
+func (m *MockInterface) GetCiraLog() (pthi.GetCiraLogResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCiraLog")
+	ret0, _ := ret[0].(pthi.GetCiraLogResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCiraLog indicates an expected call of GetCiraLog.
+func (mr *MockInterfaceMockRecorder) GetCiraLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCiraLog", reflect.TypeOf((*MockInterface)(nil).GetCiraLog))
 }
 
 // GetControlMode mocks base method.

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -102,6 +103,10 @@ func (c MockAMT) GetFlog() ([]byte, error) {
 
 func (c MockAMT) StopConfiguration() (amt.StopConfigurationResponse, error) {
 	return amt.StopConfigurationResponse{}, nil
+}
+
+func (c MockAMT) GetCiraLog() (pthi.GetCiraLogResponse, error) {
+	return pthi.GetCiraLogResponse{}, nil
 }
 
 var p Payload

--- a/pkg/amt/commands.go
+++ b/pkg/amt/commands.go
@@ -186,6 +186,7 @@ type Interface interface {
 	StartConfigurationHBased(params SecureHBasedParameters) (SecureHBasedResponse, error)
 	GetFlog() ([]byte, error)
 	StopConfiguration() (StopConfigurationResponse, error)
+	GetCiraLog() (pthi.GetCiraLogResponse, error)
 }
 
 func ANSI2String(ansi pthi.AMTANSIString) string {
@@ -637,4 +638,20 @@ func (amt AMTCommand) GetFlog() ([]byte, error) {
 	log.Debugf("Successfully retrieved %d bytes of FLOG data", len(flogData))
 
 	return flogData, nil
+}
+
+func (amt AMTCommand) GetCiraLog() (pthi.GetCiraLogResponse, error) {
+	err := amt.PTHI.Open(false)
+	if err != nil {
+		return pthi.GetCiraLogResponse{}, err
+	}
+
+	defer amt.PTHI.Close()
+
+	result, err := amt.PTHI.GetCiraLog()
+	if err != nil {
+		return pthi.GetCiraLogResponse{}, err
+	}
+
+	return result, nil
 }

--- a/pkg/amt/commands_test.go
+++ b/pkg/amt/commands_test.go
@@ -93,6 +93,10 @@ func (c MockPTHICommands) IsChangeToAMTEnabled() (state uint8, err error) {
 	return uint8(0x83), nil
 }
 
+func (c MockPTHICommands) GetCiraLog() (pthi.GetCiraLogResponse, error) {
+	return pthi.GetCiraLogResponse{}, nil
+}
+
 var (
 	SetOperationsStateStatus       = pthi.Status(0)
 	SetOperationsStateError  error = nil

--- a/pkg/pthi/types.go
+++ b/pkg/pthi/types.go
@@ -203,6 +203,11 @@ const (
 	START_CONFIGURATION_HBASED_RESPONSE = 0x480008b
 )
 
+const (
+	GET_CIRA_LOG_REQUEST  = 0x400008e
+	GET_CIRA_LOG_RESPONSE = 0x480008e
+)
+
 type AMTUnicodeString struct {
 	Length uint16
 	String [UNICODE_STRING_LEN]uint8
@@ -423,4 +428,130 @@ type StopConfigurationRequest struct {
 
 type StopConfigurationResponse struct {
 	Header ResponseMessageHeader
+}
+
+// CIRA Log structures
+const (
+	MAX_IPV6_ADDRESSES     = 6
+	MAX_CONNECTION_DETAILS = 2
+)
+
+type GetCiraLogRequest struct {
+	Header  MessageHeader
+	Version uint8
+}
+
+type IPv6Address struct {
+	Address [16]uint8
+}
+
+type IPv6AddressEntry struct {
+	Address IPv6Address
+	Type    uint8
+	State   uint8
+}
+
+type IPParameters struct {
+	DhcpMode              uint8
+	Reserved              [3]uint8 // Padding for 4-byte alignment
+	IpAddress             uint32
+	DefaultGatewayAddress uint32
+	PrimaryDnsAddress     uint32
+	SecondaryDnsAddress   uint32
+	DomainName            [192]uint8 // CHAR[NET_DOMAIN_NAME_MAX_LENGTH]
+	IPv6DefaultRouter     IPv6Address
+	PrimaryDNS            IPv6Address
+	SecondaryDNS          IPv6Address
+	IPv6Addresses         [MAX_IPV6_ADDRESSES]IPv6AddressEntry
+}
+
+type InterfaceData struct {
+	InterfacePresent uint8
+	LinkStatus       uint8
+	IPParameters     IPParameters
+	Reserved         [306]uint8 // Padding to align to 676 bytes total (370 bytes data + 306 bytes padding)
+}
+
+type WirelessAdditionalData struct {
+	ProfileName [33]byte // CHAR[33]
+	HostControl uint8    // UINT8
+}
+
+type WiredAdditionalData struct {
+	AuthResult802_1x    uint8 // UINT8
+	AuthSubResult802_1x uint8 // UINT8
+	WiredMediaType      uint8 // UINT8
+	DiscreteLanStatus   uint8 // UINT8
+}
+
+type ConnectionDetail struct {
+	ConnectionStatus uint32     // CIRA_LOG_CONNECTION_STATUS enum (4 bytes)
+	ProxyUsed        uint8      // UINT8 (1 byte)
+	ProxyName        [256]uint8 // UINT8[NET_FQDN_MAX_LENGTH]
+	TcpFailureCode   uint32     // CIRA_LOGGER_TCP_ERROR enum (4 bytes)
+	TlsFailureCode   int32      // INT32 (4 bytes)
+}
+
+type TunnelClosureInfo struct {
+	ClosureTimestamp      uint32
+	ClosedByMps           uint8
+	APF_DISCONNECT_REASON uint8
+	ClosureReason         uint8
+	Reserved              [3]uint8 // Padding for 4-byte alignment
+}
+
+type CIRATunnelLogEntry struct {
+	Valid                         uint8
+	OpenTimestamp                 uint32
+	RemoteAccessConnectionTrigger uint8
+	Reserved1                     [3]uint8   // Padding for 4-byte alignment
+	MpsHostname                   [256]uint8 // CHAR[NET_FQDN_MAX_LENGTH]
+	ProxyUsed                     uint8
+	ProxyName                     [256]uint8 // UINT8[NET_FQDN_MAX_LENGTH]
+	AuthenticationMethod          uint8
+	ConnectedInterface            uint8
+	Reserved2                     [3]uint8 // Padding for 4-byte alignment
+	LastKeepAlive                 uint32
+	KeepAliveInterval             uint32
+	TunnelClosureInfo             TunnelClosureInfo
+}
+
+type CIRAFailedConnectionLogEntry struct {
+	Valid                         uint8
+	OpenTimestamp                 uint32
+	RemoteAccessConnectionTrigger uint8
+	Reserved1                     [3]uint8   // Padding for 4-byte alignment
+	MpsHostname                   [256]uint8 // CHAR[NET_FQDN_MAX_LENGTH]
+	AuthenticationMethod          uint8
+	// Structure layout: InterfaceData[0] (370B data + 306B pad) + InterfaceData[1] (370B data + 306B pad) = 1352B total
+	// Each InterfaceData includes full IPv6 support: IPv6DefaultRouter, PrimaryDNS, SecondaryDNS, IPv6Addresses[6]
+	// Then WirelessAdditionalData (34B) + WiredAdditionalData (4B) come after the InterfaceData array
+	InterfaceData              [2]InterfaceData
+	WirelessAdditionalData     WirelessAdditionalData
+	WiredAdditionalData        WiredAdditionalData
+	ConnectedInterface         uint8
+	Reserved2                  [3]uint8 // Padding for 4-byte alignment
+	ConnectionDetails          [MAX_CONNECTION_DETAILS]ConnectionDetail
+	TunnelEstablishmentFailure TunnelClosureInfo
+}
+
+type CIRAStatusSummary struct {
+	IsTunnelOpened            uint8
+	CurrentConnectionState    uint8
+	Reserved                  [3]uint8 // Padding for 4-byte alignment
+	LastKeepAlive             uint32
+	KeepAliveInterval         uint32
+	LastConnectionStatus      uint8
+	LastConnectionTimestamp   uint32
+	LastTunnelStatus          uint8
+	LastTunnelOpenedTimestamp uint32
+	LastTunnelClosedTimestamp uint32
+}
+
+type GetCiraLogResponse struct {
+	Header                   ResponseMessageHeader
+	Version                  uint8
+	CiraStatusSummary        CIRAStatusSummary
+	LastFailedTunnelLogEntry CIRATunnelLogEntry
+	FailedConnectionLogEntry CIRAFailedConnectionLogEntry
 }


### PR DESCRIPTION
Implements the rpc cira-log command to retrieve CIRA (Client Initiated Remote Access) connection logs and status from Intel AMT via PTHI interface.

Resolves #1003