### PR TITLE
refactor: correct GetFlogSize to read UINT32

### DIFF
--- a/pkg/hotham/types.go
+++ b/pkg/hotham/types.go
@@ -107,7 +107,7 @@ type GetFlogSizeRequest struct {
 // GetFlogSizeResponse contains the Flash Log size
 type GetFlogSizeResponse struct {
 	Header HOTHAMHeader
-	Size   uint16 // Size in bytes
+	Size   uint32 // Size in bytes (UINT32 per spec)
 }
 
 // GetFlogRequest requests the Flash Log data


### PR DESCRIPTION
* Changed FlogSize from uint16 (2 bytes) to uint32 (4 bytes) to match Intel HOTHAM specification.
* Cleaned up Windows trace logs.
* Updated Linux GUID to match Windows standard format.