### PR TITLE
fix: updating redirection log proccess using thread safe and buffer

### DIFF
--- a/cmd/rpc/lib.go
+++ b/cmd/rpc/lib.go
@@ -15,10 +15,31 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
+
+// ThreadSafeWriter is a thread-safe writer that collects output
+type ThreadSafeWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *ThreadSafeWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.Write(p)
+}
+
+func (w *ThreadSafeWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.buf.String()
+}
 
 //export rpcCheckAccess
 func rpcCheckAccess() int {
@@ -32,29 +53,81 @@ func rpcCheckAccess() int {
 
 //export rpcExec
 func rpcExec(Input *C.char, Output **C.char) int {
-
 	defer func() {
 		if r := recover(); r != nil {
 			println("Recovered panic: %v", r)
 		}
 	}()
 
-	// Save the current stdout and redirect temporarily
+	// Save the current stdout, stderr, and logger output
 	oldStdout := os.Stdout
-	outR, outW, _ := os.Pipe()
-	os.Stdout = outW
-
-	// Save the current stderr and redirect temporarily
 	oldStderr := os.Stderr
-	os.Stderr = outW
+	oldLogOutput := log.StandardLogger().Out
 
-	// Redirect logger output too to avoid printing from rpc library
-	log.SetOutput(outW)
+	// Create pipes to capture output
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		log.Error("Failed to create stdout pipe:", err)
+		*Output = C.CString("")
+
+		return utils.GenericFailure.Code
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		log.Error("Failed to create stderr pipe:", err)
+		*Output = C.CString("")
+
+		return utils.GenericFailure.Code
+	}
+
+	// Create a thread-safe writer to collect all output
+	outputWriter := &ThreadSafeWriter{}
+
+	// Redirect stdout, stderr, and logger
+	os.Stdout = wOut
+	os.Stderr = wErr
+	log.SetOutput(wOut)
+
+	// Use WaitGroup to track goroutines
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine to read from stdout pipe
+	go func() {
+		defer wg.Done()
+		io.Copy(outputWriter, rOut)
+	}()
+
+	// Goroutine to read from stderr pipe
+	go func() {
+		defer wg.Done()
+		io.Copy(outputWriter, rErr)
+	}()
+
+	// Ensure everything is restored and output is captured
+	defer func() {
+		// Close write ends of pipes to signal EOF to readers
+		wOut.Close()
+		wErr.Close()
+
+		// Wait for all readers to finish
+		wg.Wait()
+
+		// Restore original outputs
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+		log.SetOutput(oldLogOutput)
+
+		// Close read ends
+		rOut.Close()
+		rErr.Close()
+
+		// Set the output
+		*Output = C.CString(outputWriter.String())
+	}()
 
 	if accessStatus := rpcCheckAccess(); accessStatus != int(utils.Success) {
 		log.Error(AccessErrMsg)
-		captureAndRestoreOutput(outW, outR, oldStdout, oldStderr, Output)
-
 		return accessStatus
 	}
 
@@ -64,26 +137,20 @@ func rpcExec(Input *C.char, Output **C.char) int {
 	r := csv.NewReader(strings.NewReader(inputString))
 	r.Comma = ' ' // space
 
-	args, err := r.Read()
-	if err != nil {
-		log.Error(err.Error())
-		captureAndRestoreOutput(outW, outR, oldStdout, oldStderr, Output)
-
+	args, readErr := r.Read()
+	if readErr != nil {
+		log.Error(readErr.Error())
 		return utils.InvalidParameterCombination.Code
 	}
 
 	args = append([]string{"rpc"}, args...)
 
-	err = runRPC(args)
-	if err != nil {
+	execErr := runRPC(args)
+	if execErr != nil {
 		log.Error("rpcExec failed: " + inputString)
-		errCode := handleError(err)
-		captureAndRestoreOutput(outW, outR, oldStdout, oldStderr, Output)
 
-		return errCode
+		return handleError(execErr)
 	}
-
-	captureAndRestoreOutput(outW, outR, oldStdout, oldStderr, Output)
 
 	return int(utils.Success)
 }
@@ -98,13 +165,4 @@ func handleError(err error) int {
 
 		return utils.GenericFailure.Code
 	}
-}
-
-func captureAndRestoreOutput(writeFile *os.File, readFile *os.File, oldStdout *os.File, oldStderr *os.File, Output **C.char) {
-	writeFile.Close()
-	var outBuf bytes.Buffer
-	io.Copy(&outBuf, readFile)
-	os.Stdout = oldStdout
-	os.Stderr = oldStderr
-	*Output = C.CString(outBuf.String())
 }


### PR DESCRIPTION
**Problem:** When using os.Pipe() in a Go DLL called from C#, it can cause deadlocks because writing to the pipe may block if there is no active reader in a separate goroutine, using threads (c# code) and executing the activation  flow with the verbose flag enabled. During c2c client module activation, the RPC activation thread blocks the entire process, resulting in a hung activation flow.

Issue: Using rpc activation with verbose flag enable:

<img width="1024" height="249" alt="rpsPipeIssue" src="https://github.com/user-attachments/assets/e3d4a905-f8c7-46a8-8400-52ed55c9f575" />

Technical Changes
1. Dual Pipe Architecture
Created separate pipes for stdout and stderr (prevents pipe buffer overflow and potential deadlocks)
Each pipe has dedicated read/write ends for proper stream isolation
2. Asynchronous Reading with Goroutines
2 background goroutines continuously read from pipes using [io.Copy()](vscode-file://vscode-app/c:/Users/casanche/AppData/Local/Programs/Microsoft%20VS%20Code/bdd88df003/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
sync.WaitGroup ensures all data is read before returning to C#
Non-blocking design prevents main thread from waiting on I/O operations
3. Thread-Safe Output Collection
ThreadSafeWriter struct with mutex protection for concurrent access
Safely accumulates output from multiple goroutines
4. Single Cleanup Point
Replaced 4 duplicate captureAndRestoreOutput() calls with one defer block
Guarantees proper resource cleanup on all exit paths (success, error, panic)
Correct shutdown sequence: close writers → wait for readers → restore state

Smoke Test:
- rpc without -v flag
<img width="1024" height="136" alt="rpcFix1" src="https://github.com/user-attachments/assets/07d4b7f7-74e8-40a8-b3c6-ed071b32a433" />

- rpc with -v flag
<img width="1024" height="352" alt="rpcFix2" src="https://github.com/user-attachments/assets/94002ba1-3519-4e09-ab2a-204a193dbc3b" />