### PR TITLE
fix: rpc configure command panic issue when subcommands are not provided

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,7 +82,10 @@ func (g *Globals) AfterApply(ctx *kong.Context) error {
 func Parse(args []string, amtCommand amt.Interface) (*kong.Context, *CLI, error) {
 	var cli CLI
 
-	helpOpts := kong.HelpOptions{Compact: true}
+	helpOpts := kong.HelpOptions{
+		Compact:        true,
+		ValueFormatter: kong.DefaultHelpValueFormatter,
+	}
 
 	// Build kong options with YAML configuration resolver (if file exists)
 	kongOpts := []kong.Option{


### PR DESCRIPTION
Addresses: https://github.com/device-management-toolkit/rpc-go/issues/1148

**Before fix:**
```
$ sudo ./rpc-command configure
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x594968]

goroutine 1 [running]:
github.com/alecthomas/kong.writeFlags(0xc0000378a0, {0xc0000104e0?, 0x6?, 0xb2e4c5?})
        /home/hspe/go/pkg/mod/github.com/alecthomas/kong@v1.14.0/help.go:452 +0x2a8
github.com/alecthomas/kong.printNodeDetail.func1()
        /home/hspe/go/pkg/mod/github.com/alecthomas/kong@v1.14.0/help.go:194 +0x11a
github.com/alecthomas/kong.printNodeDetail(0xc00021e410, 0xc0000be4b0, 0x1)
        /home/hspe/go/pkg/mod/github.com/alecthomas/kong@v1.14.0/help.go:199 +0x586
github.com/alecthomas/kong.printCommand(0xc00021e410, 0xc000032040, 0xc0000be4b0)
        /home/hspe/go/pkg/mod/github.com/alecthomas/kong@v1.14.0/help.go:158 +0xed
github.com/alecthomas/kong.DefaultHelpPrinter({0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, 0xc00003ed00)
        /home/hspe/go/pkg/mod/github.com/alecthomas/kong@v1.14.0/help.go:133 +0xe8
github.com/device-management-toolkit/rpc-go/v2/internal/cli.PrintHelp(0xc000185ce0?, {0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, ...)
        /home/hspe/shradha/configure_bug/rpc-go/internal/cli/cli.go:134 +0x65
github.com/device-management-toolkit/rpc-go/v2/internal/cli.Parse({0xc00012a000, 0x2, 0x2}, {0xc16cd0, 0xc00011e2d0})
        /home/hspe/shradha/configure_bug/rpc-go/internal/cli/cli.go:119 +0x689
github.com/device-management-toolkit/rpc-go/v2/internal/cli.ExecuteWithAMT({0xc00012a000?, 0xc000185f08?, 0x0?}, {0xc16cd0, 0xc00011e2d0})
        /home/hspe/shradha/configure_bug/rpc-go/internal/cli/cli.go:156 +0x2f
github.com/device-management-toolkit/rpc-go/v2/internal/cli.Execute({0xc00012a000, 0x2, 0x2})
        /home/hspe/shradha/configure_bug/rpc-go/internal/cli/cli.go:150 +0x112
main.main()
        /home/hspe/shradha/configure_bug/rpc-go/cmd/rpc/main.go:33 +0x28
```


**After Fix:**
```
$ sudo ./rpc-command-fix-v6 configure
Usage: rpc configure <command> [flags]

Configure AMT settings including ethernet, wireless, TLS, and other features

Flags:
  -h, --help                                 Show context-sensitive help.
      --log-level="info"                     Set log level ($RPC_LOG_LEVEL)
  -j, --json                                 Output in JSON format ($RPC_JSON)
  -v, --verbose                              Enable verbose logging ($RPC_VERBOSE)
  -n, --skip-cert-check                      Skip certificate verification for remote HTTPS/WSS (RPS) connections
                                             (insecure) ($RPC_SKIP_CERT_CHECK)
      --skip-amt-cert-check                  Skip certificate verification when connecting to AMT/LMS over TLS
                                             (insecure) ($RPC_SKIP_AMT_CERT_CHECK)
      --tenantid=STRING                      Tenant ID for multi-tenant environments for use with RPS ($TENANT_ID)
      --lmsaddress="localhost"               LMS address to connect to ($RPC_LMSADDRESS)
      --lmsport="16992"                      LMS port to connect to ($RPC_LMSPORT)
      --password=STRING                      AMT admin password applied globally to all AMT operations
                                             ($AMT_PASSWORD)
      --auth-token=STRING                    Bearer token for server authentication ($AUTH_TOKEN)
      --auth-username=STRING                 Username for basic auth (used when no token) ($AUTH_USERNAME)
      --auth-password=STRING                 Password for basic auth (used when no token) ($AUTH_PASSWORD)
      --auth-endpoint="/api/v1/authorize"    The endpoint to call to fetch a token. Assumes the same host as the
                                             profile URL unless an absolute URL is provided; defaults to the Console
                                             path /api/v1/authorize ($RPC_AUTH_ENDPOINT).

Commands:
  configure mebx (setmebx)                     Configure MEBx password
  configure amt-password (amtpassword,changeamtpassword)
                                               Change AMT password
  configure amt-features (amtfeatures,setamtfeatures)
                                               Configure AMT features (KVM, SOL, IDER, user consent)
  configure enable-amt (enable-op-state,enable-operational-state)
                                               Enable AMT operational state (requires unprovisioned state)
  configure disable-amt (disable-op-state,disable-operational-state)
                                               Disable AMT operational state (requires unprovisioned state)
  configure cira                               Configure Cloud-Initiated Remote Access (CIRA)
  configure sync-clock (syncclock,synctime)    Synchronize host OS clock to AMT
  configure wi-fi-sync (wifisync,wifi)         Control WiFi and local profile synchronization
  configure wireless (wireless,wifi,addwifisettings)
                                               Configure WiFi settings
  configure wired (wired,ethernet,addethernetsettings)
                                               Configure wired ethernet settings
  configure tls (tls,configuretls)             Configure TLS settings
  configure proxy (proxy,httpproxy)            Configure HTTP proxy access point for firmware-initiated connections
  configure hostname (synchostname,sethostname)
                                               Synchronize host OS hostname and DNS suffix to AMT general settings
```

