### PR TITLE
refactor: adds support for mps port

### DIFF
--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -71,22 +71,18 @@ type AmtInfoCmd struct {
 	URL  string `help:"Endpoint URL of the devices API (e.g., https://mps.example.com/api/v1/devices)" name:"url"`
 }
 
-// RequiresAMTPassword indicates whether this command requires AMT password
-// For amtinfo, password is only required for user certificate operations
+// RequiresAMTPassword indicates whether this command requires AMT password.
+// amtinfo never requires a password prompt — it uses the Local System Account (LSA) for WSMAN.
 func (cmd *AmtInfoCmd) RequiresAMTPassword() bool {
-	log.Trace("Checking if amtinfo requires AMT password")
-	// Password is required for user cert operations when device is provisioned (control mode != 0).
-	return cmd.IsUserCertRequested() && cmd.GetControlMode() != 0
+	return false
 }
 
 // Validate implements Kong's extensible validation interface for business logic validation
 func (cmd *AmtInfoCmd) Validate(kctx *kong.Context) error {
-	// For amtinfo, skip WSMAN setup unless user certificates are explicitly requested.
-	// Avoid any hardware/driver access during validation to keep tests hermetic.
-	cmd.SkipWSMANSetup = !cmd.UserCert && !cmd.All
+	// amtinfo handles its own WSMAN setup internally via ensureWSMANClient (using LSA).
+	cmd.SkipWSMANSetup = true
 
 	log.Trace("Validating amtinfo command")
-	// Defer password prompting to Run(), where control mode is available (set in AfterApply).
 
 	// Basic validation for sync mode
 	if cmd.Sync {
@@ -106,11 +102,6 @@ func (cmd *AmtInfoCmd) Validate(kctx *kong.Context) error {
 	return nil
 }
 
-// IsUserCertRequested checks if user certificates are requested
-func (cmd *AmtInfoCmd) IsUserCertRequested() bool {
-	return cmd.UserCert || cmd.All
-}
-
 // HasNoFlagsSet checks if no specific flags are set (meaning show all)
 func (cmd *AmtInfoCmd) HasNoFlagsSet() bool {
 	return !cmd.Ver && !cmd.Bld && !cmd.Sku && !cmd.UUID && !cmd.UPID && !cmd.Mode && !cmd.ProvState && !cmd.DNS &&
@@ -119,16 +110,7 @@ func (cmd *AmtInfoCmd) HasNoFlagsSet() bool {
 
 // Run executes the amtinfo command
 func (cmd *AmtInfoCmd) Run(ctx *Context) error {
-	// If user requested user certificates or --all, prompt for password at runtime.
 	log.Trace("Running amtinfo command")
-
-	if err := cmd.EnsureAMTPassword(ctx, cmd); err != nil {
-		return err
-	}
-	// If password now present and user certs requested, build WSMAN client
-	if err := cmd.EnsureWSMAN(ctx); err != nil {
-		return err
-	}
 
 	service := NewInfoService(ctx.AMTCommand)
 	service.jsonOutput = ctx.JsonOutput
@@ -136,7 +118,6 @@ func (cmd *AmtInfoCmd) Run(ctx *Context) error {
 	service.localTLSEnforced = cmd.LocalTLSEnforced
 	// Use AMT-specific skip flag for WSMAN/TLS to firmware
 	service.skipAMTCertCheck = ctx.SkipAMTCertCheck
-	// Reuse the already-initialized WSMAN client from AMTBaseCmd (initialized in AfterApply when userCert is requested)
 	service.wsman = cmd.GetWSManClient()
 
 	// If syncing, ensure we collect full device info regardless of selective flags
@@ -478,10 +459,42 @@ func (s *InfoService) GetAMTInfo(cmd *AmtInfoCmd) (*InfoResult, error) {
 		}
 	}
 
+	// Ensure WSMAN client is set up once for any operations that need it (RAS, UserCert)
+	if showAll || cmd.Ras || cmd.UserCert {
+		if controlMode == -1 {
+			controlMode, controlModeErr = s.amtCommand.GetControlMode()
+		}
+
+		if controlModeErr == nil {
+			if err := s.ensureWSMANClient(controlMode); err != nil {
+				log.Debug("WSMAN client setup failed, WSMAN features unavailable: ", err)
+			}
+		}
+	}
+
 	// Get RAS (Remote Access Status)
 	if showAll || cmd.Ras {
+		// Try WSMAN first for MPS hostname + port
+		var (
+			wsmanHostname string
+			wsmanPort     int
+			wsmanErr      error
+		)
+
+		wsmanHostname, wsmanPort, wsmanErr = s.getMPSInfoFromWSMAN()
+		if wsmanErr != nil {
+			log.Debug("Failed to get MPS info from WSMAN, will use HECI: ", wsmanErr)
+		}
+
+		// Always call HECI for NetworkStatus, RemoteStatus, RemoteTrigger
 		ras, err := s.amtCommand.GetRemoteAccessConnectionStatus()
 		if err == nil {
+			if wsmanErr == nil {
+				// WSMAN succeeded: use WSMAN hostname + port
+				ras.MPSHostname = wsmanHostname
+				ras.MPSPort = wsmanPort
+			}
+			// If WSMAN failed, HECI hostname is already in ras.MPSHostname; port stays 0
 			result.RAS = &ras
 		}
 	}
@@ -512,24 +525,13 @@ func (s *InfoService) GetAMTInfo(cmd *AmtInfoCmd) (*InfoResult, error) {
 		}
 	}
 
-	// Get user certificates (requires WSMAN client setup)
-	if showAll || cmd.UserCert {
-		// Get control mode if not already retrieved
-		if controlMode == -1 {
-			controlMode, _ = s.amtCommand.GetControlMode()
-		}
-
-		if controlMode == 0 {
-			log.Debug("Device is in pre-provisioning mode, user certificates are not available")
-		}
-
-		if s.password != "" {
-			userCerts, err := s.getUserCertificates(controlMode)
-			if err != nil {
-				log.Error("Failed to get user certificates: ", err)
-			} else {
-				result.UserCerts = userCerts
-			}
+	// Get user certificates (WSMAN client already set up above)
+	if cmd.All || cmd.UserCert {
+		userCerts, err := s.getUserCertificates()
+		if err != nil {
+			log.Error("Failed to get user certificates: ", err)
+		} else {
+			result.UserCerts = userCerts
 		}
 	}
 
@@ -599,6 +601,10 @@ func (s *InfoService) OutputText(result *InfoResult, cmd *AmtInfoCmd) error {
 		fmt.Printf("RAS Remote Status\t: %s\n", result.RAS.RemoteStatus)
 		fmt.Printf("RAS Trigger\t\t: %s\n", result.RAS.RemoteTrigger)
 		fmt.Printf("RAS MPS Hostname\t: %s\n", result.RAS.MPSHostname)
+
+		if result.RAS.MPSPort > 0 {
+			fmt.Printf("RAS MPS Port\t\t: %d\n", result.RAS.MPSPort)
+		}
 	}
 
 	// Output wired adapter information
@@ -653,7 +659,7 @@ func (s *InfoService) OutputText(result *InfoResult, cmd *AmtInfoCmd) error {
 	}
 
 	// Output user certificates (separate from system certs)
-	if showAll || cmd.UserCert {
+	if cmd.All || cmd.UserCert {
 		if len(result.UserCerts) > 0 {
 			fmt.Println("---Public Key Certs---")
 
@@ -762,59 +768,108 @@ func (s *InfoService) getMajorVersion(version string) (int, error) {
 	return majorVersion, nil
 }
 
-// getUserCertificates retrieves public key certificates via WSMAN
-func (s *InfoService) getUserCertificates(controlMode int) (map[string]UserCert, error) {
-	// Control mode is passed as parameter to avoid duplicate checks
-	if controlMode == 0 {
-		return nil, fmt.Errorf("device is in pre-provisioning mode, user certificates are not available")
-	}
-
-	// Prefer an existing, already-initialized WSMAN client to avoid duplicate LMS connections/logs
-	var wsmanClient interfaces.WSMANer
+// ensureWSMANClient sets up s.wsman once if not already initialized.
+// Uses the AMT password if available, otherwise falls back to LSA credentials.
+func (s *InfoService) ensureWSMANClient(controlMode int) error {
 	if s.wsman != nil {
-		wsmanClient = s.wsman
-	} else {
-		// Create and setup a temporary client as a fallback
-		wsmanClient = localamt.NewGoWSMANMessages(utils.LMSAddress)
-
-		// Setup TLS configuration
-		var tlsConfig *tls.Config
-		if s.localTLSEnforced {
-			tlsConfig = certs.GetTLSConfig(&controlMode, nil, s.skipAMTCertCheck)
-		} else {
-			tlsConfig = &tls.Config{InsecureSkipVerify: s.skipAMTCertCheck}
-		}
-
-		if err := wsmanClient.SetupWsmanClient("admin", s.password, s.localTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig); err != nil {
-			return nil, fmt.Errorf("failed to setup WSMAN client: %w", err)
-		}
+		return nil
 	}
 
-	// Get public key certificates
-	publicKeyCerts, err := wsmanClient.GetPublicKeyCerts()
+	if controlMode == 0 {
+		return fmt.Errorf("device is in pre-provisioning mode")
+	}
+
+	username := "admin"
+	password := s.password
+
+	// If no password provided, use local system account credentials
+	if password == "" {
+		lsa, err := s.amtCommand.GetLocalSystemAccount()
+		if err != nil {
+			return fmt.Errorf("failed to get local system account: %w", err)
+		}
+
+		username = lsa.Username
+		password = lsa.Password
+	}
+
+	// Check LMS connectivity before attempting WSMAN setup to avoid local transport fallback which hangs.
+	port := utils.LMSPort
+	if s.localTLSEnforced {
+		port = utils.LMSTLSPort
+	}
+
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+
+	conn, err := dialer.DialContext(context.Background(), "tcp4", utils.LMSAddress+":"+port)
+	if err != nil {
+		return fmt.Errorf("LMS not available: %w", err)
+	}
+
+	conn.Close()
+
+	wsmanClient := localamt.NewGoWSMANMessages(utils.LMSAddress)
+
+	var tlsConfig *tls.Config
+	if s.localTLSEnforced {
+		tlsConfig = certs.GetTLSConfig(&controlMode, nil, s.skipAMTCertCheck)
+	} else {
+		tlsConfig = &tls.Config{InsecureSkipVerify: s.skipAMTCertCheck}
+	}
+
+	if err := wsmanClient.SetupWsmanClient(username, password, s.localTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig); err != nil {
+		return fmt.Errorf("failed to setup WSMAN client: %w", err)
+	}
+
+	s.wsman = wsmanClient
+
+	return nil
+}
+
+// getUserCertificates retrieves public key certificates via WSMAN
+func (s *InfoService) getUserCertificates() (map[string]UserCert, error) {
+	if s.wsman == nil {
+		return nil, fmt.Errorf("WSMAN client not available")
+	}
+
+	publicKeyCerts, err := s.wsman.GetPublicKeyCerts()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get public key certificates: %w", err)
 	}
 
-	// Process certificates into user cert map
 	userCertMap := make(map[string]UserCert)
 
 	for _, cert := range publicKeyCerts {
-		// Get certificate name from CN in subject, fallback to InstanceID
 		name := utils.GetTokenFromKeyValuePairs(cert.Subject, "CN")
 		if name == "" {
 			name = cert.InstanceID
 		}
 
-		userCert := UserCert{
+		userCertMap[name] = UserCert{
 			Subject:                cert.Subject,
 			Issuer:                 cert.Issuer,
 			TrustedRootCertificate: cert.TrustedRootCertificate,
 			ReadOnlyCertificate:    cert.ReadOnlyCertificate,
 		}
-
-		userCertMap[name] = userCert
 	}
 
 	return userCertMap, nil
+}
+
+// getMPSInfoFromWSMAN retrieves MPS hostname and port via WSMAN ManagementPresenceRemoteSAP.
+func (s *InfoService) getMPSInfoFromWSMAN() (hostname string, port int, err error) {
+	if s.wsman == nil {
+		return "", 0, fmt.Errorf("WSMAN client not available")
+	}
+
+	items, err := s.wsman.GetMPSSAP()
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get MPS SAP: %w", err)
+	}
+
+	if len(items) == 0 {
+		return "", 0, fmt.Errorf("no MPS entries found")
+	}
+
+	return items[0].AccessInfo, items[0].Port, nil
 }

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/managementpresence"
 	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/stretchr/testify/assert"
@@ -135,6 +136,8 @@ func TestAmtInfoCmd_Run_WithSync(t *testing.T) {
 	mockAMT.EXPECT().GetChangeEnabled().Return(amt.ChangeEnabledResponse(0), nil).AnyTimes()
 	mockAMT.EXPECT().GetDNSSuffix().Return("example.com", nil)
 	mockAMT.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+
+	mockAMT.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "192.168.1.100"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE"}, nil)
@@ -189,6 +192,8 @@ func TestAmtInfoCmd_Run_WithSync_BearerAuth(t *testing.T) {
 	mockAMT.EXPECT().GetChangeEnabled().Return(amt.ChangeEnabledResponse(0), nil).AnyTimes()
 	mockAMT.EXPECT().GetDNSSuffix().Return("example.com", nil)
 	mockAMT.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+
+	mockAMT.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "192.168.1.100"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE"}, nil)
@@ -227,6 +232,8 @@ func TestAmtInfoCmd_Run_WithSync_UserPass_TokenExchange_DefaultEndpoint(t *testi
 	mockAMT.EXPECT().GetChangeEnabled().Return(amt.ChangeEnabledResponse(0), nil).AnyTimes()
 	mockAMT.EXPECT().GetDNSSuffix().Return("example.com", nil)
 	mockAMT.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+
+	mockAMT.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "192.168.1.100"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE"}, nil)
@@ -280,6 +287,8 @@ func TestAmtInfoCmd_Run_WithSync_UserPass_TokenExchange_CustomEndpoint(t *testin
 	mockAMT.EXPECT().GetChangeEnabled().Return(amt.ChangeEnabledResponse(0), nil).AnyTimes()
 	mockAMT.EXPECT().GetDNSSuffix().Return("example.com", nil)
 	mockAMT.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+
+	mockAMT.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55", IPAddress: "192.168.1.100"}, nil)
 	mockAMT.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE"}, nil)
@@ -357,6 +366,7 @@ func TestInfoService_GetAMTInfo(t *testing.T) {
 
 				m.EXPECT().GetDNSSuffix().Return("example.com", nil)
 				m.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+				m.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 				m.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{
 					NetworkStatus: "connected",
 					RemoteStatus:  "connected",
@@ -432,11 +442,12 @@ func TestInfoService_GetAMTInfo(t *testing.T) {
 			cmd:  &AmtInfoCmd{UserCert: true},
 			setupMock: func(m *mock.MockInterface) {
 				m.EXPECT().GetControlMode().Return(1, nil) // Provisioned mode
+				m.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *InfoResult) {
-				// UserCert should be disabled due to missing password
-				assert.Empty(t, result.CertificateHashes)
+				// UserCert unavailable because WSMAN client setup failed (no LSA in test)
+				assert.Nil(t, result.UserCerts)
 			},
 		},
 		{
@@ -900,6 +911,8 @@ func TestInfoService_GetAMTInfo_ErrorCases(t *testing.T) {
 			name: "GetRemoteAccessConnectionStatus error",
 			cmd:  &AmtInfoCmd{Ras: true},
 			setupMock: func(m *mock.MockInterface) {
+				m.EXPECT().GetControlMode().Return(1, nil)
+				m.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 				m.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, errors.New("RAS not available"))
 			},
 			wantErr: false,
@@ -988,20 +1001,16 @@ func TestInfoService_GetAMTInfo_AdditionalCoverage(t *testing.T) {
 		validate  func(*testing.T, *InfoResult)
 	}{
 		{
-			name: "UserCert with password provided",
+			name: "UserCert without WSMAN available",
 			cmd:  &AmtInfoCmd{UserCert: true},
 			setupMock: func(m *mock.MockInterface) {
-				// Mock GetControlMode call for UserCert check
-				m.EXPECT().GetControlMode().Return(1, nil) // Return "Admin Control Mode" (provisioned)
-				// Note: WSMAN client setup will fail in tests since there's no real device
-				// This is expected behavior - the user cert retrieval will fail but the command should not error
+				m.EXPECT().GetControlMode().Return(1, nil)
+				m.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result *InfoResult) {
-				// UserCerts should be empty since WSMAN client setup fails in tests
-				assert.Empty(t, result.UserCerts)
-				// No other fields should be populated since only UserCert flag is set
-				assert.Empty(t, result.CertificateHashes)
+				// UserCerts should be nil since WSMAN client setup fails
+				assert.Nil(t, result.UserCerts)
 			},
 		},
 		{
@@ -1064,6 +1073,7 @@ func TestInfoService_GetAMTInfo_AdditionalCoverage(t *testing.T) {
 				m.EXPECT().GetChangeEnabled().Return(response, nil)
 				m.EXPECT().GetDNSSuffix().Return("example.com", nil)
 				m.EXPECT().GetOSDNSSuffix().Return("os.example.com", nil)
+				m.EXPECT().GetLocalSystemAccount().Return(amt.LocalSystemAccount{}, errors.New("not available"))
 				m.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{}, nil)
 				m.EXPECT().GetLANInterfaceSettings(false).Return(amt.InterfaceSettings{MACAddress: "00:11:22:33:44:55"}, nil)
 				m.EXPECT().GetLANInterfaceSettings(true).Return(amt.InterfaceSettings{MACAddress: "00:AA:BB:CC:DD:EE"}, nil)
@@ -1109,6 +1119,88 @@ func TestInfoService_GetAMTInfo_AdditionalCoverage(t *testing.T) {
 	}
 }
 
+func TestInfoService_GetAMTInfo_RAS_WSMANSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+	// Only RAS flag set; controlMode starts at -1 so GetControlMode will be called
+	mockAMT.EXPECT().GetControlMode().Return(1, nil)
+	mockWSMAN.EXPECT().GetMPSSAP().Return([]managementpresence.ManagementRemoteResponse{
+		{AccessInfo: "wsman-mps.example.com", Port: 4433},
+	}, nil)
+	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{
+		NetworkStatus: "connected",
+		RemoteStatus:  "connected",
+		RemoteTrigger: "user",
+		MPSHostname:   "heci-mps.example.com",
+	}, nil)
+
+	service := NewInfoService(mockAMT)
+	service.wsman = mockWSMAN
+
+	result, err := service.GetAMTInfo(&AmtInfoCmd{Ras: true})
+	assert.NoError(t, err)
+	assert.NotNil(t, result.RAS)
+	// WSMAN hostname + port should override HECI hostname
+	assert.Equal(t, "wsman-mps.example.com", result.RAS.MPSHostname)
+	assert.Equal(t, 4433, result.RAS.MPSPort)
+	// Status fields come from HECI
+	assert.Equal(t, "connected", result.RAS.NetworkStatus)
+	assert.Equal(t, "connected", result.RAS.RemoteStatus)
+	assert.Equal(t, "user", result.RAS.RemoteTrigger)
+}
+
+func TestInfoService_GetAMTInfo_RAS_WSMANFallbackToHECI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+	mockAMT.EXPECT().GetControlMode().Return(1, nil)
+	mockWSMAN.EXPECT().GetMPSSAP().Return(nil, errors.New("WSMAN error"))
+	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{
+		NetworkStatus: "connected",
+		RemoteStatus:  "not connected",
+		RemoteTrigger: "alert",
+		MPSHostname:   "heci-mps.example.com",
+	}, nil)
+
+	service := NewInfoService(mockAMT)
+	service.wsman = mockWSMAN
+
+	result, err := service.GetAMTInfo(&AmtInfoCmd{Ras: true})
+	assert.NoError(t, err)
+	assert.NotNil(t, result.RAS)
+	// WSMAN failed, so HECI hostname is used and port stays 0
+	assert.Equal(t, "heci-mps.example.com", result.RAS.MPSHostname)
+	assert.Equal(t, 0, result.RAS.MPSPort)
+	assert.Equal(t, "connected", result.RAS.NetworkStatus)
+}
+
+func TestInfoService_GetAMTInfo_RAS_PreProvisioningMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAMT := mock.NewMockInterface(ctrl)
+
+	// Control mode 0 = pre-provisioning; ensureWSMANClient skips setup, so WSMAN falls back to HECI
+	mockAMT.EXPECT().GetControlMode().Return(0, nil)
+	mockAMT.EXPECT().GetRemoteAccessConnectionStatus().Return(amt.RemoteAccessStatus{
+		MPSHostname: "heci-mps.example.com",
+	}, nil)
+
+	service := NewInfoService(mockAMT)
+	result, err := service.GetAMTInfo(&AmtInfoCmd{Ras: true})
+	assert.NoError(t, err)
+	assert.NotNil(t, result.RAS)
+	assert.Equal(t, "heci-mps.example.com", result.RAS.MPSHostname)
+	assert.Equal(t, 0, result.RAS.MPSPort)
+}
+
 func TestInfoService_OutputText_AdditionalCoverage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1150,6 +1242,40 @@ func TestInfoService_OutputText_AdditionalCoverage(t *testing.T) {
 			validate: func(t *testing.T, output string) {
 				assert.Contains(t, output, "DNS Suffix\t\t: example.com")
 				assert.Contains(t, output, "DNS Suffix (OS)\t\t: ")
+			},
+		},
+		{
+			name: "RAS with MPS port",
+			result: &InfoResult{
+				RAS: &amt.RemoteAccessStatus{
+					NetworkStatus: "connected",
+					RemoteStatus:  "connected",
+					RemoteTrigger: "user",
+					MPSHostname:   "mps.example.com",
+					MPSPort:       4433,
+				},
+			},
+			cmd: &AmtInfoCmd{Ras: true},
+			validate: func(t *testing.T, output string) {
+				assert.Contains(t, output, "RAS MPS Hostname\t: mps.example.com")
+				assert.Contains(t, output, "RAS MPS Port\t\t: 4433")
+			},
+		},
+		{
+			name: "RAS without MPS port",
+			result: &InfoResult{
+				RAS: &amt.RemoteAccessStatus{
+					NetworkStatus: "connected",
+					RemoteStatus:  "not connected",
+					RemoteTrigger: "alert",
+					MPSHostname:   "mps.example.com",
+					MPSPort:       0,
+				},
+			},
+			cmd: &AmtInfoCmd{Ras: true},
+			validate: func(t *testing.T, output string) {
+				assert.Contains(t, output, "RAS MPS Hostname\t: mps.example.com")
+				assert.NotContains(t, output, "RAS MPS Port")
 			},
 		},
 		{

--- a/internal/commands/integration_test.go
+++ b/internal/commands/integration_test.go
@@ -34,42 +34,16 @@ func TestRefactoredPasswordFunctionality(t *testing.T) {
 		assert.False(t, cmd.RequiresAMTPassword(), "Remote deactivate should not require password")
 	})
 
-	t.Run("AmtInfoCmd conditional password requirements", func(t *testing.T) {
-		// Start with control mode = 0 (pre-provisioning)
-		cmd := &AmtInfoCmd{
-			AMTBaseCmd: AMTBaseCmd{ControlMode: 0},
-		}
+	t.Run("AmtInfoCmd never requires password (uses LSA)", func(t *testing.T) {
+		cmd := &AmtInfoCmd{}
+		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo should never require password")
 
-		ctx := &Context{
-			AMTPassword: "test-password",
-		}
-		// Test that password is accessible
-		assert.Equal(t, "test-password", ctx.AMTPassword)
-
-		// Test password requirement logic
-		// Without user certs, no password required
-		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo without user certs should not require password")
-
-		// Test with user certificates
 		cmd.UserCert = true
-		// With user certificates, still no password when control mode == 0
-		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo with user certs should not require password when control mode is 0")
-
-		// Test with All flag (includes user certs)
-		cmd.UserCert = false
-		cmd.All = true
-		// With --all, still no password when control mode == 0
-		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo with --all should not require password when control mode is 0")
-
-		// Now set control mode to non-zero (provisioned) and test again
-		cmd.All = false
-		cmd.UserCert = true
-		cmd.ControlMode = 2 // any non-zero indicates provisioned
-		assert.True(t, cmd.RequiresAMTPassword(), "amtinfo with user certs should require password when control mode is non-zero")
+		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo with user certs should not require password")
 
 		cmd.UserCert = false
 		cmd.All = true
-		assert.True(t, cmd.RequiresAMTPassword(), "amtinfo with --all should require password when control mode is non-zero")
+		assert.False(t, cmd.RequiresAMTPassword(), "amtinfo with --all should not require password")
 	})
 
 	t.Run("Base command provides common functionality", func(t *testing.T) {

--- a/pkg/amt/commands.go
+++ b/pkg/amt/commands.go
@@ -55,6 +55,7 @@ type RemoteAccessStatus struct {
 	RemoteStatus  string `json:"remoteStatus"`
 	RemoteTrigger string `json:"remoteTrigger"`
 	MPSHostname   string `json:"mpsHostname"`
+	MPSPort       int    `json:"mpsPort,omitempty"`
 }
 
 // CertHashEntry is the GO struct for holding Cert Hash Entries

--- a/pkg/amt/commands_test.go
+++ b/pkg/amt/commands_test.go
@@ -340,6 +340,7 @@ func TestGetRemoteAccessConnectionStatus(t *testing.T) {
 	assert.Equal(t, "not connected", result.RemoteStatus)
 	assert.Equal(t, "user initiated", result.RemoteTrigger)
 	assert.Equal(t, "Test", result.MPSHostname)
+	assert.Equal(t, 0, result.MPSPort) // HECI does not return port
 }
 
 func TestGetLANInterfaceSettingsTrue(t *testing.T) {


### PR DESCRIPTION
* Implement WSMAN fallback to retrieve MPS hostname and port via AMT_ManagementPresenceRemoteSAP when HECI returns incomplete data
* Use GetLocalSystemAccount() to obtain AMT credentials for WSMAN authentication

Resolves #1140