### PR TITLE
refactor: fetch wsman classes data using rpc diagnostics command

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -74,12 +74,30 @@ func TestParse(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, ctx)
 			assert.NotNil(t, cli)
-
 			if tt.expected != "" {
 				// Check that the correct command was selected
 				assert.Equal(t, tt.expected, ctx.Selected().Name)
 			}
 		})
+	}
+}
+
+func TestParse_WSManCommandAliases(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAMT := mock.NewMockInterface(ctrl)
+
+	aliasArgs := [][]string{
+		{"rpc", "diag", "wsman", "list"},
+		{"rpc", "diag", "ws-man", "list"},
+	}
+
+	for _, args := range aliasArgs {
+		ctx, cli, err := Parse(args, mockAMT)
+		assert.NoError(t, err)
+		assert.NotNil(t, ctx)
+		assert.NotNil(t, cli)
 	}
 }
 

--- a/internal/commands/diagnostics/diagnostics.go
+++ b/internal/commands/diagnostics/diagnostics.go
@@ -18,6 +18,6 @@ type DiagnosticsBaseCmd struct {
 type DiagnosticsCmd struct {
 	CIRA   CIRACmd   `cmd:"cira"   help:"Dump CIRA-related diagnostics"`
 	CSME   CSMECmd   `cmd:"csme"   help:"Dump CSME / firmware flash diagnostics"`
-	WSMan  WSManCmd  `cmd:"wsman" aliases:"ws-man" help:"Dump AMT WSMAN class(es)"`
+	WSMan  WSManCmd  `cmd:"" name:"wsman" aliases:"ws-man" help:"Dump AMT WSMAN class(es)"`
 	Bundle BundleCmd `cmd:"bundle" help:"Collect a full diagnostics bundle"`
 }

--- a/internal/commands/diagnostics/wsman.go
+++ b/internal/commands/diagnostics/wsman.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"html"
 	"net"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
 	localamt "github.com/device-management-toolkit/rpc-go/v2/internal/local/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -73,16 +75,16 @@ type classResult struct {
 	XML   string `json:"-" xml:",cdata"`
 }
 
-type unsupportedClassData struct {
+type classFetchErrorData struct {
 	Class   string `json:"class" xml:"Class"`
 	Status  string `json:"status" xml:"Status"`
 	Message string `json:"message" xml:"Message"`
 }
 
-type classFetchErrorData struct {
-	Class   string `json:"class" xml:"Class"`
-	Status  string `json:"status" xml:"Status"`
-	Message string `json:"message" xml:"Message"`
+type rawWSMANClassData struct {
+	Class       string `json:"class" xml:"Class"`
+	ResourceURI string `json:"resourceUri" xml:"ResourceURI"`
+	XMLOutput   string `json:"xmlOutput" xml:"XMLOutput"`
 }
 
 type xmlResults struct {
@@ -92,55 +94,55 @@ type xmlResults struct {
 
 var wsmanClassFetchers = map[string]classFetcher{
 	"AMT_8021XProfile":                    fetchAMT8021XProfile,
-	"AMT_AssetTable":                      unsupportedClassFetcher("AMT_AssetTable"),
-	"AMT_AssetTableService":               unsupportedClassFetcher("AMT_AssetTableService"),
+	"AMT_AssetTable":                      rawWSMANClassFetcher("AMT_AssetTable"),
+	"AMT_AssetTableService":               rawWSMANClassFetcher("AMT_AssetTableService"),
 	"AMT_AuditLog":                        fetchAMTAuditLog,
 	"AMT_BootCapabilities":                fetchAMTBootCapabilities,
 	"AMT_BootSettingData":                 fetchAMTBootSettingData,
-	"AMT_CryptographicCapabilities":       unsupportedClassFetcher("AMT_CryptographicCapabilities"),
+	"AMT_CryptographicCapabilities":       rawWSMANClassFetcher("AMT_CryptographicCapabilities"),
 	"AMT_EnvironmentDetectionSettingData": fetchAMTEnvironmentDetectionSettingData,
-	"AMT_EventLogEntry":                   unsupportedClassFetcher("AMT_EventLogEntry"),
+	"AMT_EventLogEntry":                   rawWSMANClassFetcher("AMT_EventLogEntry"),
 	"AMT_EthernetPortSettings":            fetchAMTEthernetPortSettings,
 	"AMT_GeneralSettings":                 fetchAMTGeneralSettings,
-	"AMT_Hdr8021Filter":                   unsupportedClassFetcher("AMT_Hdr8021Filter"),
+	"AMT_Hdr8021Filter":                   rawWSMANClassFetcher("AMT_Hdr8021Filter"),
 	"AMT_ManagementPresenceRemoteSAP":     fetchAMTManagementPresenceRemoteSAP,
 	"AMT_MessageLog":                      fetchAMTMessageLog,
 	"AMT_RedirectionService":              fetchAMTRedirectionService,
-	"AMT_RemoteAccessCapabilities":        fetchAMTRemoteAccessCapabilities,
+	"AMT_RemoteAccessCapabilities":        rawWSMANClassFetcher("AMT_RemoteAccessCapabilities"),
 	"AMT_RemoteAccessPolicyAppliesToMPS":  fetchAMTRemoteAccessPolicyAppliesToMPS,
 	"AMT_RemoteAccessPolicyRule":          fetchAMTRemoteAccessPolicyRule,
 	"AMT_SetupAndConfigurationService":    fetchAMTSetupAndConfigurationService,
-	"AMT_SystemPowerScheme":               unsupportedClassFetcher("AMT_SystemPowerScheme"),
-	"AMT_TimeSynchronizationService":      fetchAMTTimeSynchronizationService,
+	"AMT_SystemPowerScheme":               rawWSMANClassFetcher("AMT_SystemPowerScheme"),
+	"AMT_TimeSynchronizationService":      rawWSMANClassFetcher("AMT_TimeSynchronizationService"),
 	"AMT_UserInitiatedConnectionService":  fetchAMTUserInitiatedConnectionService,
-	"AMT_WiFiPortConfigurationService":    fetchAMTWiFiPortConfigurationService,
-	"CIM_BIOSFeature":                     unsupportedClassFetcher("CIM_BIOSFeature"),
+	"AMT_WiFiPortConfigurationService":    rawWSMANClassFetcher("AMT_WiFiPortConfigurationService"),
+	"CIM_BIOSFeature":                     rawWSMANClassFetcher("CIM_BIOSFeature"),
 	"CIM_BIOSElement":                     fetchCIMBIOSElement,
 	"CIM_Card":                            fetchCIMCard,
 	"CIM_Chassis":                         fetchCIMChassis,
 	"CIM_ComputerSystemPackage":           fetchCIMComputerSystemPackage,
-	"CIM_EthernetPort":                    unsupportedClassFetcher("CIM_EthernetPort"),
+	"CIM_EthernetPort":                    rawWSMANClassFetcher("CIM_EthernetPort"),
 	"CIM_KVMRedirectionSAP":               fetchCIMKVMRedirectionSAP,
-	"CIM_PowerManagementCapabilities":     unsupportedClassFetcher("CIM_PowerManagementCapabilities"),
+	"CIM_PowerManagementCapabilities":     rawWSMANClassFetcher("CIM_PowerManagementCapabilities"),
 	"CIM_PowerManagementService":          fetchCIMPowerManagementService,
 	"CIM_Processor":                       fetchCIMProcessor,
-	"CIM_RedirectionService":              unsupportedClassFetcher("CIM_RedirectionService"),
+	"CIM_RedirectionService":              rawWSMANClassFetcher("CIM_RedirectionService"),
 	"CIM_SoftwareIdentity":                fetchCIMSoftwareIdentity,
-	"CIM_WiFiEndpoint":                    unsupportedClassFetcher("CIM_WiFiEndpoint"),
-	"CIM_WiFiEndpointCapabilities":        unsupportedClassFetcher("CIM_WiFiEndpointCapabilities"),
-	"CIM_WiFiEndpointSettings":            fetchCIMWiFiEndpointSettings,
-	"CIM_WiFiPort":                        fetchCIMWiFiPort,
-	"CIM_WiFiPortCapabilities":            unsupportedClassFetcher("CIM_WiFiPortCapabilities"),
+	"CIM_WiFiEndpoint":                    rawWSMANClassFetcher("CIM_WiFiEndpoint"),
+	"CIM_WiFiEndpointCapabilities":        rawWSMANClassFetcher("CIM_WiFiEndpointCapabilities"),
+	"CIM_WiFiEndpointSettings":            rawWSMANClassFetcher("CIM_WiFiEndpointSettings"),
+	"CIM_WiFiPort":                        rawWSMANClassFetcher("CIM_WiFiPort"),
+	"CIM_WiFiPortCapabilities":            rawWSMANClassFetcher("CIM_WiFiPortCapabilities"),
 	"IPS_HostBasedSetupService":           fetchIPSHostBasedSetupService,
-	"IPS_HostBootReason":                  unsupportedClassFetcher("IPS_HostBootReason"),
-	"IPS_HostIPSettings":                  unsupportedClassFetcher("IPS_HostIPSettings"),
+	"IPS_HostBootReason":                  rawWSMANClassFetcher("IPS_HostBootReason"),
+	"IPS_HostIPSettings":                  rawWSMANClassFetcher("IPS_HostIPSettings"),
 	"IPS_HTTPProxyAccessPoint":            fetchIPSHTTPProxyAccessPoint,
 	"IPS_IEEE8021xSettings":               fetchIPSIEEE8021xSettings,
-	"IPS_IPv6PortSettings":                unsupportedClassFetcher("IPS_IPv6PortSettings"),
+	"IPS_IPv6PortSettings":                rawWSMANClassFetcher("IPS_IPv6PortSettings"),
 	"IPS_KVMRedirectionSettingData":       fetchIPSKVMRedirectionSettingData,
-	"IPS_LANEndpoint":                     unsupportedClassFetcher("IPS_LANEndpoint"),
+	"IPS_LANEndpoint":                     rawWSMANClassFetcher("IPS_LANEndpoint"),
 	"IPS_OptInService":                    fetchIPSOptInService,
-	"IPS_ProvisioningRecordLog":           unsupportedClassFetcher("IPS_ProvisioningRecordLog"),
+	"IPS_ProvisioningRecordLog":           rawWSMANClassFetcher("IPS_ProvisioningRecordLog"),
 	"IPS_ScreenSettingData":               fetchIPSScreenSettingData,
 	"IPS_SecIOService":                    fetchIPSSecIOService,
 }
@@ -394,10 +396,6 @@ func renderTableResults(results []classResult) ([]byte, error) {
 }
 
 func extractClassInstances(className string, data any) ([][]tableRow, error) {
-	if _, ok := data.(unsupportedClassData); ok {
-		return nil, nil
-	}
-
 	if _, ok := data.(classFetchErrorData); ok {
 		return nil, nil
 	}
@@ -566,7 +564,12 @@ func fetchAMTEnvironmentDetectionSettingData(messages wsman.Messages) (any, erro
 }
 
 func fetchAMTMessageLog(messages wsman.Messages) (any, error) {
-	return messages.AMT.MessageLog.GetRecords(1, 390)
+	enumerateResponse, err := messages.AMT.MessageLog.Enumerate()
+	if err != nil {
+		return nil, err
+	}
+
+	return messages.AMT.MessageLog.Pull(enumerateResponse.Body.EnumerateResponse.EnumerationContext)
 }
 
 func fetchAMTEthernetPortSettings(messages wsman.Messages) (any, error) {
@@ -591,10 +594,6 @@ func fetchAMTRedirectionService(messages wsman.Messages) (any, error) {
 	return messages.AMT.RedirectionService.Get()
 }
 
-func fetchAMTRemoteAccessCapabilities(messages wsman.Messages) (any, error) {
-	return messages.AMT.RemoteAccessService.Get()
-}
-
 func fetchAMTRemoteAccessPolicyRule(messages wsman.Messages) (any, error) {
 	enumerateResponse, err := messages.AMT.RemoteAccessPolicyRule.Enumerate()
 	if err != nil {
@@ -617,16 +616,8 @@ func fetchAMTSetupAndConfigurationService(messages wsman.Messages) (any, error) 
 	return messages.AMT.SetupAndConfigurationService.Get()
 }
 
-func fetchAMTWiFiPortConfigurationService(messages wsman.Messages) (any, error) {
-	return messages.AMT.WiFiPortConfigurationService.Get()
-}
-
 func fetchAMTUserInitiatedConnectionService(messages wsman.Messages) (any, error) {
 	return messages.AMT.UserInitiatedConnectionService.Get()
-}
-
-func fetchAMTTimeSynchronizationService(messages wsman.Messages) (any, error) {
-	return messages.AMT.TimeSynchronizationService.GetLowAccuracyTimeSynch()
 }
 
 func fetchCIMBIOSElement(messages wsman.Messages) (any, error) {
@@ -675,24 +666,6 @@ func fetchCIMKVMRedirectionSAP(messages wsman.Messages) (any, error) {
 	return messages.CIM.KVMRedirectionSAP.Get()
 }
 
-func fetchCIMWiFiEndpointSettings(messages wsman.Messages) (any, error) {
-	enumerateResponse, err := messages.CIM.WiFiEndpointSettings.Enumerate()
-	if err != nil {
-		return nil, err
-	}
-
-	return messages.CIM.WiFiEndpointSettings.Pull(enumerateResponse.Body.EnumerateResponse.EnumerationContext)
-}
-
-func fetchCIMWiFiPort(messages wsman.Messages) (any, error) {
-	enumerateResponse, err := messages.CIM.WiFiPort.Enumerate()
-	if err != nil {
-		return nil, err
-	}
-
-	return messages.CIM.WiFiPort.Pull(enumerateResponse.Body.EnumerateResponse.EnumerationContext)
-}
-
 func fetchIPSHostBasedSetupService(messages wsman.Messages) (any, error) {
 	return messages.IPS.HostBasedSetupService.Get()
 }
@@ -722,12 +695,118 @@ func fetchIPSHTTPProxyAccessPoint(messages wsman.Messages) (any, error) {
 	return messages.IPS.HTTPProxyAccessPointService.Pull(enumerateResponse.Body.EnumerateResponse.EnumerationContext)
 }
 
-func unsupportedClassFetcher(className string) classFetcher {
+func rawWSMANClassFetcher(className string) classFetcher {
 	return func(messages wsman.Messages) (any, error) {
-		return unsupportedClassData{
-			Class:   className,
-			Status:  "not_supported",
-			Message: "not exposed by current go-wsman-messages API",
+		resourceURI, err := classResourceURI(className)
+		if err != nil {
+			return nil, err
+		}
+
+		enumerationContext, err := wsmanEnumerate(messages, resourceURI)
+		if err != nil {
+			return nil, err
+		}
+
+		pullXML, err := wsmanPull(messages, resourceURI, enumerationContext)
+		if err != nil {
+			return nil, err
+		}
+
+		return rawWSMANClassData{
+			Class:       className,
+			ResourceURI: resourceURI,
+			XMLOutput:   pullXML,
 		}, nil
 	}
+}
+
+func classResourceURI(className string) (string, error) {
+	switch {
+	case strings.HasPrefix(className, "AMT_"):
+		return "http://intel.com/wbem/wscim/1/amt-schema/1/" + className, nil
+	case strings.HasPrefix(className, "CIM_"):
+		return "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/" + className, nil
+	case strings.HasPrefix(className, "IPS_"):
+		return "http://intel.com/wbem/wscim/1/ips-schema/1/" + className, nil
+	default:
+		return "", fmt.Errorf("unsupported class prefix for %s", className)
+	}
+}
+
+func wsmanEnumerate(messages wsman.Messages, resourceURI string) (string, error) {
+	toAddress := wsmanEndpoint(messages)
+	envelope := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tns="%s" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"><soap:Header><wsa:To>%s</wsa:To><wsa:ReplyTo><wsa:Address soap:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address></wsa:ReplyTo><wsa:Action soap:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Enumerate</wsa:Action><wsman:MaxEnvelopeSize soap:mustUnderstand="true">51200</wsman:MaxEnvelopeSize><wsa:MessageID>uuid:%s</wsa:MessageID><wsman:ResourceURI soap:mustUnderstand="true">%s</wsman:ResourceURI><wsman:OperationTimeout>PT60.000S</wsman:OperationTimeout></soap:Header><soap:Body><wsen:Enumerate /></soap:Body></soap:Envelope>`, resourceURI, toAddress, uuid.NewString(), resourceURI)
+
+	response, err := messages.Client.Post(envelope)
+	if err != nil {
+		return "", err
+	}
+
+	var root xmlNode
+	if err := xml.Unmarshal(response, &root); err != nil {
+		return "", err
+	}
+
+	node := findFirstNodeByLocalName(root, "EnumerationContext")
+	if node == nil {
+		return "", fmt.Errorf("enumeration context not found in response")
+	}
+
+	enumerationContext := strings.TrimSpace(nodeInnerText(*node))
+	if enumerationContext == "" {
+		return "", fmt.Errorf("empty enumeration context in response")
+	}
+
+	return enumerationContext, nil
+}
+
+func wsmanPull(messages wsman.Messages, resourceURI, enumerationContext string) (string, error) {
+	escapedContext := html.EscapeString(enumerationContext)
+	toAddress := wsmanEndpoint(messages)
+	envelope := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tns="%s" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"><soap:Header><wsa:To>%s</wsa:To><wsa:ReplyTo><wsa:Address soap:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address></wsa:ReplyTo><wsa:Action soap:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/Pull</wsa:Action><wsman:MaxEnvelopeSize soap:mustUnderstand="true">51200</wsman:MaxEnvelopeSize><wsa:MessageID>uuid:%s</wsa:MessageID><wsman:ResourceURI soap:mustUnderstand="true">%s</wsman:ResourceURI><wsman:OperationTimeout>PT60.000S</wsman:OperationTimeout></soap:Header><soap:Body><wsen:Pull><wsen:EnumerationContext>%s</wsen:EnumerationContext><wsen:MaxElements>101</wsen:MaxElements></wsen:Pull></soap:Body></soap:Envelope>`, resourceURI, toAddress, uuid.NewString(), resourceURI, escapedContext)
+
+	response, err := messages.Client.Post(envelope)
+	if err != nil {
+		return "", err
+	}
+
+	return string(response), nil
+}
+
+func findFirstNodeByLocalName(node xmlNode, localName string) *xmlNode {
+	if node.XMLName.Local == localName {
+		matched := node
+
+		return &matched
+	}
+
+	for _, child := range node.Children {
+		matched := findFirstNodeByLocalName(child, localName)
+		if matched != nil {
+			return matched
+		}
+	}
+
+	return nil
+}
+
+func wsmanEndpoint(messages wsman.Messages) string {
+	target, ok := messages.Client.(*client.Target)
+	if !ok {
+		return "/wsman"
+	}
+
+	value := reflect.ValueOf(target)
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+
+	endpointField := value.FieldByName("endpoint")
+	if endpointField.IsValid() && endpointField.Kind() == reflect.String {
+		if endpoint := endpointField.String(); endpoint != "" {
+			return endpoint
+		}
+	}
+
+	return "/wsman"
 }

--- a/internal/commands/diagnostics/wsman_test.go
+++ b/internal/commands/diagnostics/wsman_test.go
@@ -197,14 +197,14 @@ func TestRenderResults_Table(t *testing.T) {
 	assert.True(t, strings.Contains(output, "0"))
 }
 
-func TestRenderResults_TableNoInstancesForUnsupported(t *testing.T) {
+func TestRenderResults_TableNoInstancesForFetchError(t *testing.T) {
 	results := []classResult{
 		{
 			Class: "AMT_AssetTable",
-			Data: unsupportedClassData{
+			Data: classFetchErrorData{
 				Class:   "AMT_AssetTable",
-				Status:  "not_supported",
-				Message: "not exposed",
+				Status:  "fetch_failed",
+				Message: "mock fetch error",
 			},
 		},
 	}
@@ -214,7 +214,7 @@ func TestRenderResults_TableNoInstancesForUnsupported(t *testing.T) {
 
 	output := string(rendered)
 	assert.True(t, strings.Contains(output, "No instances found for class: AMT_AssetTable"))
-	assert.False(t, strings.Contains(output, "not_supported"))
+	assert.False(t, strings.Contains(output, "fetch_failed"))
 }
 
 func TestRenderResults_UnsupportedFormat(t *testing.T) {


### PR DESCRIPTION
Addresses - https://github.com/device-management-toolkit/rpc-go/issues/1005
implementation flow - https://github.com/device-management-toolkit/rpc-go/wiki/Design-doc-for-AMT-WSMAN-Class-data-fetch-feature
diag ws-man command design - https://github.com/device-management-toolkit/rpc-go/wiki/RPC-Diagnostic-Command-Design-Document

Improvements w.r.t removal of raw ws-man parsing for classes not supported in ws-man would be handled through: https://github.com/device-management-toolkit/go-wsman-messages/issues/654 

sample o/p:

```
$ sudo ./rpc diagnostics ws-man get -c AMT_GeneralSettings --format table
[sudo] password for user:
Class: AMT_GeneralSettings
Name                           Value
AMTNetworkEnabled              1
DDNSPeriodicUpdateInterval     1440
DDNSTTL                        900
DDNSUpdateByDHCPServerEnabled  true
DDNSUpdateEnabled              false
DHCPSyncRequiresHostname       1
DHCPv6ConfigurationTimeout     0
DigestRealm                    Digest:EA16DDD9CD407949CC64B6B4B0EA5E51
DomainName
ElementName                    Intel(r) AMT: General Settings
HostName
HostOSFQDN                     BA38RNL00667.iind.intel.com
IdleWakeTimeout                65535
InstanceID                     Intel(r) AMT: General Settings
NetworkInterfaceEnabled        true
PingResponseEnabled            true
PowerSource                    0
PreferredAddressFamily         0
PresenceNotificationInterval   0
PrivacyLevel                   0
RmcpPingResponseEnabled        true
SharedFQDN                     true
ThunderboltDockEnabled         0
WsmanOnlyMode                  false
------------------------------------------------------------------------------------------------------------------------------------
$ sudo ./rpc diagnostics ws-man get --class AMT_GeneralSettings --format json
AMT Password:
[
  {
    "class": "AMT_GeneralSettings",
    "data": {
      "XMLInput": "\u003c?xml version=\"1.0\" encoding=\"utf-8\"?\u003e\u003cEnvelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:a=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:w=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\" xmlns=\"http://www.w3.org/2003/05/soap-envelope\"\u003e\u003cHeader\u003e\u003ca:Action\u003ehttp://schemas.xmlsoap.org/ws/2004/09/transfer/Get\u003c/a:Action\u003e\u003ca:To\u003e/wsman\u003c/a:To\u003e\u003cw:ResourceURI\u003ehttp://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings\u003c/w:ResourceURI\u003e\u003ca:MessageID\u003e0\u003c/a:MessageID\u003e\u003ca:ReplyTo\u003e\u003ca:Address\u003ehttp://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous\u003c/a:Address\u003e\u003c/a:ReplyTo\u003e\u003cw:OperationTimeout\u003ePT60S\u003c/w:OperationTimeout\u003e\u003c/Header\u003e\u003cBody\u003e\u003c/Body\u003e\u003c/Envelope\u003e",
      "XMLOutput": "\u003c?xml version=\"1.0\" encoding=\"UTF-8\"?\u003e\u003ca:Envelope xmlns:a=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:b=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\" xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/02/trust\" xmlns:e=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:f=\"http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd\" xmlns:g=\"http://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\u003e\u003ca:Header\u003e\u003cb:To\u003ehttp://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous\u003c/b:To\u003e\u003cb:RelatesTo\u003e0\u003c/b:RelatesTo\u003e\u003cb:Action a:mustUnderstand=\"true\"\u003ehttp://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse\u003c/b:Action\u003e\u003cb:MessageID\u003euuid:00000000-8086-8086-8086-0000000007E2\u003c/b:MessageID\u003e\u003cc:ResourceURI\u003ehttp://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings\u003c/c:ResourceURI\u003e\u003c/a:Header\u003e\u003ca:Body\u003e\u003cg:AMT_GeneralSettings\u003e\u003cg:AMTNetworkEnabled\u003e1\u003c/g:AMTNetworkEnabled\u003e\u003cg:DDNSPeriodicUpdateInterval\u003e1440\u003c/g:DDNSPeriodicUpdateInterval\u003e\u003cg:DDNSTTL\u003e900\u003c/g:DDNSTTL\u003e\u003cg:DDNSUpdateByDHCPServerEnabled\u003etrue\u003c/g:DDNSUpdateByDHCPServerEnabled\u003e\u003cg:DDNSUpdateEnabled\u003efalse\u003c/g:DDNSUpdateEnabled\u003e\u003cg:DHCPSyncRequiresHostname\u003e1\u003c/g:DHCPSyncRequiresHostname\u003e\u003cg:DHCPv6ConfigurationTimeout\u003e0\u003c/g:DHCPv6ConfigurationTimeout\u003e\u003cg:DigestRealm\u003eDigest:E516C7B10457AC7B8F40E90B67070B53\u003c/g:DigestRealm\u003e\u003cg:DomainName\u003e\u003c/g:DomainName\u003e\u003cg:ElementName\u003eIntel(r) AMT: General Settings\u003c/g:ElementName\u003e\u003cg:HostName\u003e\u003c/g:HostName\u003e\u003cg:HostOSFQDN\u003eBA38RNL00667.iind.intel.com\u003c/g:HostOSFQDN\u003e\u003cg:IdleWakeTimeout\u003e65535\u003c/g:IdleWakeTimeout\u003e\u003cg:InstanceID\u003eIntel(r) AMT: General Settings\u003c/g:InstanceID\u003e\u003cg:NetworkInterfaceEnabled\u003etrue\u003c/g:NetworkInterfaceEnabled\u003e\u003cg:PingResponseEnabled\u003etrue\u003c/g:PingResponseEnabled\u003e\u003cg:PowerSource\u003e0\u003c/g:PowerSource\u003e\u003cg:PreferredAddressFamily\u003e0\u003c/g:PreferredAddressFamily\u003e\u003cg:PresenceNotificationInterval\u003e0\u003c/g:PresenceNotificationInterval\u003e\u003cg:PrivacyLevel\u003e0\u003c/g:PrivacyLevel\u003e\u003cg:RmcpPingResponseEnabled\u003etrue\u003c/g:RmcpPingResponseEnabled\u003e\u003cg:SharedFQDN\u003etrue\u003c/g:SharedFQDN\u003e\u003cg:ThunderboltDockEnabled\u003e0\u003c/g:ThunderboltDockEnabled\u003e\u003cg:WsmanOnlyMode\u003efalse\u003c/g:WsmanOnlyMode\u003e\u003c/g:AMT_GeneralSettings\u003e\u003c/a:Body\u003e\u003c/a:Envelope\u003e",
      "XMLName": {
        "Space": "http://www.w3.org/2003/05/soap-envelope",
        "Local": "Envelope"
      },
      "Header": {
        "XMLName": {
          "Space": "http://www.w3.org/2003/05/soap-envelope",
          "Local": "Header"
        },
        "To": "http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous",
        "RelatesTo": 0,
        "Action": {
          "XMLName": {
            "Space": "http://schemas.xmlsoap.org/ws/2004/08/addressing",
            "Local": "Action"
          },
          "MustUnderstand": "true",
          "Value": "http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse"
        },
        "MessageID": "uuid:00000000-8086-8086-8086-0000000007E2",
        "ResourceURI": "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings"
      },
      "Body": {
        "XMLName": {
          "Space": "http://www.w3.org/2003/05/soap-envelope",
          "Local": "Body"
        },
        "GetResponse": {
          "XMLName": {
            "Space": "http://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings",
            "Local": "AMT_GeneralSettings"
          },
          "ElementName": "Intel(r) AMT: General Settings",
          "InstanceID": "Intel(r) AMT: General Settings",
          "NetworkInterfaceEnabled": true,
          "DigestRealm": "Digest:E516C7B10457AC7B8F40E90B67070B53",
          "IdleWakeTimeout": 65535,
          "HostName": "",
          "DomainName": "",
          "PingResponseEnabled": true,
          "WsmanOnlyMode": false,
          "PreferredAddressFamily": 0,
          "DHCPv6ConfigurationTimeout": 0,
          "DDNSUpdateEnabled": false,
          "DDNSUpdateByDHCPServerEnabled": true,
          "SharedFQDN": true,
          "HostOSFQDN": "BA38RNL00667.iind.intel.com",
          "DDNSTTL": 900,
          "AMTNetworkEnabled": 1,
          "RmcpPingResponseEnabled": true,
          "DDNSPeriodicUpdateInterval": 1440,
          "PresenceNotificationInterval": 0,
          "PrivacyLevel": 0,
          "PowerSource": 0,
          "ThunderboltDockEnabled": 0,
          "OemID": 0,
          "DHCPSyncRequiresHostname": 1
        },
        "EnumerateResponse": {
          "EnumerationContext": ""
        },
        "PullResponse": {
          "XMLName": {
            "Space": "",
            "Local": ""
          },
          "GeneralSettingsItems": null
        },
        "PutResponse": {}
      }
    }
  }
]

```