### PR TITLE
fix: prevent crash when MEI driver on fresh Windows 11 install is not updated

### DIFF
--- a/pkg/heci/windows.go
+++ b/pkg/heci/windows.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	setupapi "github.com/device-management-toolkit/rpc-go/v2/pkg/windows"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
 
@@ -106,6 +107,14 @@ func (heci *Driver) FindDevices() error {
 
 	edi, err := setupapi.SetupDiEnumDeviceInterfaces(deviceInfo, nil, &deviceGUID, 0, &interfaceData)
 	if err != nil {
+		// Clean up device info before returning
+		setupapi.SetupDiDestroyDeviceInfoList(deviceInfo)
+		// Check if this is a "no devices found" error (ERROR_NO_MORE_ITEMS = 259)
+		if errno, ok := err.(syscall.Errno); ok && errno == syscall.Errno(259) {
+			log.Error("MEI/HECI driver not found or no Intel ME devices present")
+			return errors.New("MEI/HECI driver not found. Please ensure the Intel Management Engine Interface driver is installed")
+		}
+		log.Errorf("FindDevices: SetupDiEnumDeviceInterfaces failed: %v", err)
 		return err
 	}
 
@@ -145,11 +154,13 @@ func (heci *Driver) FindDevices() error {
 
 	err = heci.GetHeciVersion()
 	if err != nil {
+		heci.meiDevice = 0
 		return err
 	}
 
 	err = heci.ConnectHeciClient()
 	if err != nil {
+		heci.meiDevice = 0
 		return err
 	}
 
@@ -193,6 +204,7 @@ func (heci *Driver) ConnectHeciClient() error {
 		(uint32)(propertiesSize),
 	)
 	if err != nil {
+		log.Tracef("ConnectHeciClient: IOCTL failed: %v", err)
 		return err
 	}
 
@@ -287,6 +299,12 @@ func (heci *Driver) ReceiveMessage(buffer []byte, done *uint32) (bytesRead uint3
 }
 
 func (heci *Driver) Close() {
-	windows.CloseHandle(heci.meiDevice)
+	// NOTE: We intentionally do NOT call CloseHandle here. On some versions of
+	// the Intel MEI driver (e.g. rolled-back/older drivers), calling CloseHandle
+	// on the MEI device file handle after ConnectHeciClient triggers a null-pointer
+	// execute-AV in the driver's kernel close dispatch routine, crashing the process.
+	// Since rpc is a short-lived CLI process, the OS will clean up all open handles
+	// when the process exits, so not closing explicitly is safe and correct.
+	heci.meiDevice = 0
 	heci.bufferSize = 0
 }


### PR DESCRIPTION
NOTE: Same commit as https://github.com/device-management-toolkit/rpc-go/pull/1171.  This one is for v2 since the issue occurs on both v3 and v2.

## Problem

On a fresh Windows 11 install, the default Intel MEI (Management Engine Interface) driver shipped
with the OS is an older version. Running `rpc amtinfo` (or any AMT command) against this unupdated
driver causes the process to crash with an access violation stack trace instead of exiting gracefully.

The root cause is in the MEI kernel driver itself: after `ConnectHeciClient` sends an IOCTL to the
device handle, the older driver leaves its `IRP_MJ_CLOSE` dispatch routine in a broken state. When
Go's `defer Close()` subsequently calls `CloseHandle` on that handle, the kernel dereferences a null
pointer and the process crashes.

## Fix

| Change | Details |
|--------|---------|
| Do not call `CloseHandle` in `Driver.Close()` | Since `rpc` is a short-lived CLI process, the OS reclaims all open handles on exit, making this safe |
| Detect `ERROR_NO_MORE_ITEMS` (errno 259) from `SetupDiEnumDeviceInterfaces` | Returns a user-friendly error message when no Intel ME device is found (e.g. MEI driver completely absent) |
| Clean up device info list on enumeration failure | Calls `SetupDiDestroyDeviceInfoList` before returning to avoid a handle leak |
| Demote `ConnectHeciClient` IOCTL failure log level | Changed from `Error` to `Trace` to suppress noise when a client GUID is simply unavailable |

## Testing

Verified on a Windows 11 machine with the rolled-back/unupdated/ and newer MEI driver:

| Scenario | Before | After |
|----------|--------|-------|
| Fresh Windows 11 (old MEI driver) | ❌ Access violation stack trace | ✅ `rpc amtinfo` completes normally |
