### PR TITLE
feat: return not supported error when running cira diag cmd on unsupported platform

### DIFF
--- a/internal/commands/diagnostics/cira.go
+++ b/internal/commands/diagnostics/cira.go
@@ -49,6 +49,11 @@ func (cmd *CIRACmd) Run(ctx *commands.Context) error {
 	// Get CIRA log from firmware
 	result, err := ctx.AMTCommand.GetCiraLog()
 	if err != nil {
+		// Empty response indicates this firmware version does not support CIRA Log
+		if err.Error() == "empty response from AMT" {
+			return fmt.Errorf("CIRA Log feature is not supported in this firmware version")
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
return user-friendly error message (CIRA Log feature is not supported in this firmware version) when running on older platforms.

Addresses #1183