### PR TITLE
feat: add console device registration for local profile activation

### DIFF
--- a/internal/commands/activate/activate.go
+++ b/internal/commands/activate/activate.go
@@ -449,7 +449,7 @@ func (cmd *ActivateCmd) addDeviceToConsole(ctx *commands.Context, consoleBaseURL
 //   - Remote TLS enabled with AcceptNonSecureConnections=false → both true.
 //   - All other cases → both false.
 func (cmd *ActivateCmd) resolveTLSFlags(cfg *config.Configuration) (useTLS, allowSelfSigned bool) {
-	if cfg.Configuration.TLS.Enabled {
+	if cfg.Configuration.TLS.Enabled || cmd.LocalTLSEnforced {
 		return true, true
 	}
 
@@ -508,25 +508,74 @@ func getLocalIP() string {
 
 // runLocalProfileFullflow loads a local profile file (optionally decrypt) and runs the orchestrator
 func (cmd *ActivateCmd) runLocalProfileFullflow(ctx *commands.Context) error {
-	// Prefer existing loader for plaintext YAML
+	// Load the profile first so its TLS settings are available for device registration.
+	var cfg config.Configuration
+
 	if cmd.Key == "" {
 		c, err := profile.LoadProfile(cmd.Profile)
 		if err != nil {
 			return fmt.Errorf("failed to load profile: %w", err)
 		}
 
-		orch := orchestrator.NewProfileOrchestrator(c, ctx.AMTPassword, cmd.MEBxPassword, ctx.SkipAMTCertCheck)
-		if err := orch.ExecuteProfile(); err != nil {
+		cfg = c
+	} else {
+		c, err := cmd.loadEncryptedProfile()
+		if err != nil {
 			return err
 		}
 
-		log.Info("Profile fullflow completed successfully")
-
-		return nil
+		cfg = c
 	}
 
-	// Encrypted file path handling using go-wsman security helper
-	return cmd.runLocalEncryptedProfile(ctx)
+	// Resolve AMT/MEBx/MPS passwords — generate random ones when the profile requests it.
+	amtPassword, mebxPassword, mpsPassword, err := profile.ResolvePasswords(&cfg)
+	if err != nil {
+		return fmt.Errorf("failed to resolve passwords: %w", err)
+	}
+
+	hasCIRA := cfg.Configuration.AMTSpecific.CIRA.MPSAddress != ""
+
+	// Register device with console before activation (no-op if no auth endpoint)
+	consoleBaseURL, token, guid, err := cmd.resolveConsoleAuth(ctx)
+	if err != nil {
+		return err
+	}
+
+	if consoleBaseURL != "" {
+		if err := cmd.addDeviceToConsole(ctx, consoleBaseURL, token, guid, amtPassword, mebxPassword, mpsPassword, hasCIRA, &cfg); err != nil {
+			return fmt.Errorf("failed to add device to console: %w", err)
+		}
+	}
+
+	orch := orchestrator.NewProfileOrchestrator(cfg, ctx.AMTPassword, cmd.MEBxPassword, ctx.SkipAMTCertCheck)
+	if err := orch.ExecuteProfile(); err != nil {
+		// When CIRA configuration fails, clear the MPS password from the console
+		if errors.Is(err, orchestrator.ErrCIRAConfiguration) && mpsPassword != "" {
+			cmd.clearMPSPasswordFromConsole(consoleBaseURL, token, guid, ctx.SkipCertCheck)
+		}
+
+		return err
+	}
+
+	log.Info("Profile fullflow completed successfully")
+
+	return nil
+}
+
+// loadEncryptedProfile decrypts a local profile file using the provided key
+func (cmd *ActivateCmd) loadEncryptedProfile() (config.Configuration, error) {
+	if cmd.Key == "" {
+		return config.Configuration{}, fmt.Errorf("missing --key for encrypted profile file")
+	}
+
+	crypto := security.Crypto{EncryptionKey: cmd.Key}
+
+	cfg, err := crypto.ReadAndDecryptFile(cmd.Profile)
+	if err != nil {
+		return config.Configuration{}, fmt.Errorf("failed to decrypt profile: %w", err)
+	}
+
+	return cfg, nil
 }
 
 // looksLikeFilePath determines if the provided string looks like a file path (absolute, relative, UNC, or has an extension)
@@ -549,27 +598,41 @@ func looksLikeFilePath(p string) bool {
 	return false
 }
 
-// runLocalEncryptedProfile decrypts a local profile file using the provided key and runs orchestrator
-func (cmd *ActivateCmd) runLocalEncryptedProfile(ctx *commands.Context) error {
-	if cmd.Key == "" {
-		return fmt.Errorf("missing --key for encrypted profile file")
+// resolveConsoleAuth authenticates with the console and resolves the device GUID using AuthEndpoint.
+func (cmd *ActivateCmd) resolveConsoleAuth(ctx *commands.Context) (consoleBaseURL, token, guid string, err error) {
+	if ctx.AuthEndpoint == "" {
+		return "", "", "", nil
 	}
 
-	crypto := security.Crypto{EncryptionKey: cmd.Key}
+	lower := strings.ToLower(ctx.AuthEndpoint)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return "", "", "", nil
+	}
 
-	cfg, err := crypto.ReadAndDecryptFile(cmd.Profile)
+	parsed, err := url.Parse(ctx.AuthEndpoint)
 	if err != nil {
-		return fmt.Errorf("failed to decrypt profile: %w", err)
+		return "", "", "", fmt.Errorf("invalid auth endpoint URL: %w", err)
 	}
 
-	orch := orchestrator.NewProfileOrchestrator(cfg, ctx.AMTPassword, cmd.MEBxPassword, ctx.SkipAMTCertCheck)
-	if err := orch.ExecuteProfile(); err != nil {
-		return err
+	consoleBaseURL = fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+
+	token = ctx.AuthToken
+	if token == "" {
+		token, err = profile.Authenticate(consoleBaseURL, ctx.AuthUsername, ctx.AuthPassword, ctx.AuthEndpoint, ctx.SkipCertCheck, 0)
+		if err != nil {
+			return "", "", "", fmt.Errorf("console authentication failed: %w", err)
+		}
 	}
 
-	log.Info("Profile fullflow completed successfully")
+	guid = cmd.UUID
+	if guid == "" && ctx.AMTCommand != nil {
+		guid, err = ctx.AMTCommand.GetUUID()
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to get device UUID: %w", err)
+		}
+	}
 
-	return nil
+	return consoleBaseURL, token, guid, nil
 }
 
 // runLocalActivation executes local activation using the local service
@@ -593,6 +656,19 @@ func (cmd *ActivateCmd) runLocalActivation(ctx *commands.Context) error {
 	// Validate and execute the local command
 	if err := localCmd.Validate(); err != nil {
 		return err
+	}
+
+	// Register device with console before activation (no-op if no auth endpoint).
+	consoleBaseURL, token, guid, err := cmd.resolveConsoleAuth(ctx)
+	if err != nil {
+		return err
+	}
+
+	if consoleBaseURL != "" {
+		cfg := &config.Configuration{}
+		if err := cmd.addDeviceToConsole(ctx, consoleBaseURL, token, guid, ctx.AMTPassword, "", "", false, cfg); err != nil {
+			return fmt.Errorf("failed to add device to console: %w", err)
+		}
 	}
 
 	return localCmd.Run(ctx)

--- a/internal/commands/activate/activate_test.go
+++ b/internal/commands/activate/activate_test.go
@@ -723,3 +723,54 @@ func TestGetLocalIP(t *testing.T) {
 	assert.NotEmpty(t, ip)
 	assert.NotEqual(t, "unknown", ip, "should resolve to an IP or hostname")
 }
+
+func TestResolveConsoleAuth_NoOp(t *testing.T) {
+	t.Run("no-op when AuthEndpoint is empty", func(t *testing.T) {
+		cmd := &ActivateCmd{}
+		ctx := &commands.Context{}
+
+		baseURL, _, _, err := cmd.resolveConsoleAuth(ctx)
+		assert.NoError(t, err)
+		assert.Empty(t, baseURL)
+	})
+
+	t.Run("no-op when AuthEndpoint is relative", func(t *testing.T) {
+		cmd := &ActivateCmd{}
+		ctx := &commands.Context{}
+		ctx.AuthEndpoint = "/api/v1/authorize"
+
+		baseURL, _, _, err := cmd.resolveConsoleAuth(ctx)
+		assert.NoError(t, err)
+		assert.Empty(t, baseURL)
+	})
+}
+
+func TestResolveConsoleAuth_WithToken(t *testing.T) {
+	cmd := &ActivateCmd{UUID: "test-guid"}
+	ctx := &commands.Context{}
+	ctx.AuthToken = "my-token"
+	ctx.AuthEndpoint = "https://console.example.com/api/v1/authorize"
+
+	baseURL, token, guid, err := cmd.resolveConsoleAuth(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://console.example.com", baseURL)
+	assert.Equal(t, "my-token", token)
+	assert.Equal(t, "test-guid", guid)
+}
+
+func TestResolveConsoleAuth_UUIDFromAMT(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAMT := mock.NewMockInterface(ctrl)
+	mockAMT.EXPECT().GetUUID().Return("amt-uuid-123", nil)
+
+	cmd := &ActivateCmd{}
+	ctx := &commands.Context{AMTCommand: mockAMT}
+	ctx.AuthToken = "token"
+	ctx.AuthEndpoint = "https://console.example.com/api/v1/authorize"
+
+	_, _, guid, err := cmd.resolveConsoleAuth(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "amt-uuid-123", guid)
+}

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -110,8 +110,17 @@ func (cmd *DeactivateCmd) Run(ctx *Context) error {
 	}
 
 	if cmd.Local {
-		// For local deactivation
-		return cmd.executeLocalDeactivate(ctx)
+		// Resolve GUID before deactivation — AMT won't respond after unprovision.
+		guid, guidErr := cmd.resolveGUID(ctx)
+		if guidErr != nil && isHTTPURL(ctx.AuthEndpoint) {
+			log.Warnf("Could not resolve device GUID for console cleanup: %v", guidErr)
+		}
+
+		if err := cmd.executeLocalDeactivate(ctx); err != nil {
+			return err
+		}
+
+		return cmd.deleteDeviceFromConsole(ctx, guid)
 	}
 
 	// For remote deactivation via RPS
@@ -140,23 +149,19 @@ func (cmd *DeactivateCmd) executeRemoteDeactivate(ctx *Context) error {
 
 // authenticate, then deactivate locally and delete device from db.
 func (cmd *DeactivateCmd) executeHttpConsoleDeactivate(ctx *Context) error {
-	parsed, err := url.Parse(cmd.URL)
+	consoleBaseURL, err := parseBaseURL(cmd.URL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}
 
-	consoleBaseURL := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
-
-	// Authenticate with the console
 	token, err := cmd.authenticateWithConsole(ctx, consoleBaseURL)
 	if err != nil {
 		return fmt.Errorf("console authentication failed: %w", err)
 	}
 
-	// Resolve device GUID
-	guid, err := cmd.resolveGUID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to resolve device GUID: %w", err)
+	guid, guidErr := cmd.resolveGUID(ctx)
+	if guidErr != nil {
+		log.Warnf("Could not resolve device GUID for console cleanup: %v", guidErr)
 	}
 
 	// Ensure AMT password for local deactivation
@@ -173,7 +178,13 @@ func (cmd *DeactivateCmd) executeHttpConsoleDeactivate(ctx *Context) error {
 		return err
 	}
 
-	// Best-effort console cleanup — device is already deactivated at this point.
+	// Console cleanup — skip if GUID is not available.
+	if guid == "" {
+		log.Warn("Skipping console device deletion: device GUID is not available")
+
+		return nil
+	}
+
 	if err := device.DeleteDevice(consoleBaseURL, token, guid, ctx.SkipCertCheck); err != nil {
 		return fmt.Errorf("device deactivated but failed to delete from console: %w", err)
 	}
@@ -212,6 +223,36 @@ func (cmd *DeactivateCmd) resolveGUID(ctx *Context) (string, error) {
 	}
 
 	return "", fmt.Errorf("unable to determine device GUID; provide --uuid")
+}
+
+// deleteDeviceFromConsole deletes the device from the console using AuthEndpoint.
+// guid must be resolved before deactivation since AMT is unavailable afterwards.
+func (cmd *DeactivateCmd) deleteDeviceFromConsole(ctx *Context, guid string) error {
+	if !isHTTPURL(ctx.AuthEndpoint) {
+		return nil
+	}
+
+	if guid == "" {
+		log.Warn("Skipping console device deletion: device GUID is not available")
+
+		return nil
+	}
+
+	consoleBaseURL, err := parseBaseURL(ctx.AuthEndpoint)
+	if err != nil {
+		return fmt.Errorf("invalid auth endpoint URL: %w", err)
+	}
+
+	token, err := cmd.authenticateWithConsole(ctx, consoleBaseURL)
+	if err != nil {
+		return fmt.Errorf("console authentication failed: %w", err)
+	}
+
+	if err := device.DeleteDevice(consoleBaseURL, token, guid, ctx.SkipCertCheck); err != nil {
+		return fmt.Errorf("device deactivated but failed to delete from console: %w", err)
+	}
+
+	return nil
 }
 
 // executeLocalDeactivate handles local deactivation
@@ -290,4 +331,23 @@ func (cmd *DeactivateCmd) deactivateCCM(ctx *Context) error {
 	log.Info("Status: Device deactivated")
 
 	return nil
+}
+
+func isHTTPURL(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+
+	lower := strings.ToLower(rawURL)
+
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
+func parseBaseURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host), nil
 }

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -7,6 +7,8 @@ package commands
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
@@ -150,6 +152,7 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 		mockAMT.EXPECT().Unprovision().Return(0, nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
@@ -166,6 +169,7 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 		mockAMT.EXPECT().Unprovision().Return(0, nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
@@ -182,6 +186,7 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 		mockAMT.EXPECT().Unprovision().Return(0, errors.New("unprovision failed"))
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
@@ -199,6 +204,7 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 		mockAMT.EXPECT().Unprovision().Return(1, nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
@@ -216,6 +222,7 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 		cmd := DeactivateCmd{Local: true, PartialUnprovision: true}
@@ -234,6 +241,7 @@ func TestDeactivateCmd_Run_Local_GetControlModeFailure(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 		cmd := DeactivateCmd{Local: true}
@@ -252,6 +260,7 @@ func TestDeactivateCmd_Run_Local_UnsupportedControlMode(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 		cmd := DeactivateCmd{Local: true}
@@ -316,6 +325,7 @@ func TestDeactivateCmd_Run_Routing(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 		mockAMT.EXPECT().Unprovision().Return(0, nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
@@ -461,6 +471,7 @@ func TestRunMethodEdgeCases(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 
@@ -482,6 +493,7 @@ func TestRunMethodEdgeCases(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 
@@ -503,6 +515,7 @@ func TestRunMethodEdgeCases(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
 
 		ctx := &Context{AMTCommand: mockAMT, AMTPassword: "test-pass"}
 
@@ -571,7 +584,62 @@ func TestDeactivateCmd_ResolveGUID(t *testing.T) {
 	})
 }
 
-// Test setupTLSConfig function
+// Test deleteDeviceFromConsole no-op scenarios
+func TestDeleteDeviceFromConsole_NoOp(t *testing.T) {
+	t.Run("no-op when AuthEndpoint is empty", func(t *testing.T) {
+		cmd := &DeactivateCmd{}
+		ctx := &Context{}
+
+		err := cmd.deleteDeviceFromConsole(ctx, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("no-op when AuthEndpoint is relative", func(t *testing.T) {
+		cmd := &DeactivateCmd{}
+		ctx := &Context{}
+		ctx.AuthEndpoint = "/api/v1/authorize"
+
+		err := cmd.deleteDeviceFromConsole(ctx, "")
+		assert.NoError(t, err)
+	})
+}
+
+func TestDeleteDeviceFromConsole_WithToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/devices/test-guid", r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "Bearer my-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cmd := &DeactivateCmd{UUID: "test-guid"}
+	ctx := &Context{}
+	ctx.AuthToken = "my-token"
+	ctx.AuthEndpoint = server.URL + "/api/v1/authorize"
+
+	err := cmd.deleteDeviceFromConsole(ctx, "test-guid")
+	assert.NoError(t, err)
+}
+
+func TestDeleteDeviceFromConsole_UUIDFromAMT(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/devices/amt-guid-456", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cmd := &DeactivateCmd{}
+	ctx := &Context{}
+	ctx.AuthToken = "token"
+	ctx.AuthEndpoint = server.URL + "/api/v1/authorize"
+
+	err := cmd.deleteDeviceFromConsole(ctx, "amt-guid-456")
+	assert.NoError(t, err)
+}
+
 func TestSetupTLSConfig(t *testing.T) {
 	t.Run("TLS config with LocalTLSEnforced false", func(t *testing.T) {
 		cmd := &DeactivateCmd{}


### PR DESCRIPTION
Add orchestrate With Console flow so local profile activation (--profile file --auth-endpoint) registers the device with the console.