### PR TITLE
fix: skip WiFi configuration on devices without WiFi hardware

### DIFF
--- a/internal/commands/configure/wifisync.go
+++ b/internal/commands/configure/wifisync.go
@@ -9,8 +9,20 @@ import (
 	"fmt"
 
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
+	"github.com/device-management-toolkit/rpc-go/v2/internal/interfaces"
 	log "github.com/sirupsen/logrus"
 )
+
+// hasWiFiHardware reports whether the device has a wireless adapter.
+// AMT convention: index 0 = wired, index 1 = wireless when present.
+func hasWiFiHardware(w interfaces.WSMANer) (bool, error) {
+	ports, err := w.GetEthernetSettings()
+	if err != nil {
+		return false, err
+	}
+
+	return len(ports) >= 2 && ports[1].MACAddress != "", nil
+}
 
 // WifiSyncCmd represents WiFi port enablement
 type WifiSyncCmd struct {
@@ -29,6 +41,22 @@ type WifiSyncCmd struct {
 
 // Run executes the enable wifi port command
 func (cmd *WifiSyncCmd) Run(ctx *commands.Context) error {
+	// Ensure runtime initialization (password + WSMAN client)
+	if err := cmd.EnsureRuntime(ctx); err != nil {
+		return err
+	}
+
+	hasWiFi, err := hasWiFiHardware(cmd.WSMan)
+	if err != nil {
+		return fmt.Errorf("failed to detect WiFi hardware: %w", err)
+	}
+
+	if !hasWiFi {
+		log.Warn("Device does not have WiFi hardware; skipping WiFi sync configuration")
+
+		return nil
+	}
+
 	// Informational log reflecting desired state
 	if cmd.OSWiFiSync {
 		log.Info("Setting WiFi sync with OS: ENABLED")
@@ -41,13 +69,9 @@ func (cmd *WifiSyncCmd) Run(ctx *commands.Context) error {
 	} else {
 		log.Info("Setting UEFI WiFi profile share: DISABLED")
 	}
-	// Ensure runtime initialization (password + WSMAN client)
-	if err := cmd.EnsureRuntime(ctx); err != nil {
-		return err
-	}
 
 	// Apply requested WiFi synchronization settings; firmware will always turn WiFi on via state change
-	err := cmd.WSMan.EnableWiFi(cmd.OSWiFiSync, cmd.UEFIWiFiSync)
+	err = cmd.WSMan.EnableWiFi(cmd.OSWiFiSync, cmd.UEFIWiFiSync)
 	if err != nil {
 		log.Error("Failed to set WiFi sync/profile sharing state.")
 

--- a/internal/commands/configure/wifisync_test.go
+++ b/internal/commands/configure/wifisync_test.go
@@ -9,11 +9,33 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/commands"
 	mock "github.com/device-management-toolkit/rpc-go/v2/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
+
+// wifiCapablePorts mimics the EthernetPortSettings enumeration on a device
+// that has WiFi hardware: index 0 is wired, index 1 is wireless with a real
+// MAC address bound to the NIC.
+var wifiCapablePorts = []ethernetport.SettingsResponse{
+	{MACAddress: "aa-bb-cc-dd-ee-01"},
+	{MACAddress: "aa-bb-cc-dd-ee-02"},
+}
+
+// wifiAbsentPorts mimics a device with only a wired port and no WiFi hardware.
+var wifiAbsentPorts = []ethernetport.SettingsResponse{
+	{MACAddress: "aa-bb-cc-dd-ee-01"},
+}
+
+// wifiSlotEmptyPorts mimics a device where the wireless slot exists in the
+// enumeration but no hardware is bound (empty MACAddress). Treated as "no
+// WiFi hardware" — matches the isWifiSupportedOnDevice guard pattern.
+var wifiSlotEmptyPorts = []ethernetport.SettingsResponse{
+	{MACAddress: "aa-bb-cc-dd-ee-01"},
+	{MACAddress: ""},
+}
 
 func TestEnableWifiPortCmd_Structure(t *testing.T) {
 	cmd := &WifiSyncCmd{}
@@ -44,6 +66,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi with sync and sharing enabled
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(nil)
 
 		err := cmd.Run(ctx)
@@ -71,6 +94,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to return an error
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(errors.New("wifi enable failed"))
 
 		err := cmd.Run(ctx)
@@ -100,6 +124,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to return a connection error
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(errors.New("connection timeout"))
 
 		err := cmd.Run(ctx)
@@ -129,6 +154,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to return an authentication error
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(errors.New("authentication failed"))
 
 		err := cmd.Run(ctx)
@@ -173,6 +199,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(nil)
 
 		// Provide a minimal non-nil context (password not needed since WSMan already set)
@@ -201,6 +228,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to be called multiple times
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil).Times(3)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(nil).Times(3)
 
 		// Call the command multiple times
@@ -232,6 +260,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 
 		ctx := &commands.Context{AMTPassword: "test-pass"}
 
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(false, false).Return(nil)
 
 		err := cmd.Run(ctx)
@@ -259,6 +288,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to return a WiFi not available error
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(errors.New("WiFi hardware not available"))
 
 		err := cmd.Run(ctx)
@@ -288,6 +318,7 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		}
 
 		// Mock EnableWiFi to return an AMT not provisioned error
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiCapablePorts, nil)
 		mockWSMAN.EXPECT().EnableWiFi(true, true).Return(errors.New("AMT not provisioned"))
 
 		err := cmd.Run(ctx)
@@ -302,5 +333,77 @@ func TestEnableWifiPortCmd_Run(t *testing.T) {
 		// Test that the struct has the expected fields
 		assert.NotNil(t, cmd)
 		assert.IsType(t, ConfigureBaseCmd{}, cmd.ConfigureBaseCmd)
+	})
+
+	t.Run("wifi_slot_with_empty_mac_treated_as_absent", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+		cmd := &WifiSyncCmd{
+			ConfigureBaseCmd: ConfigureBaseCmd{
+				AMTBaseCmd: commands.AMTBaseCmd{WSMan: mockWSMAN},
+			},
+			OSWiFiSync:   true,
+			UEFIWiFiSync: true,
+		}
+
+		ctx := &commands.Context{AMTPassword: "test-pass"}
+
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiSlotEmptyPorts, nil)
+
+		err := cmd.Run(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no_wifi_hardware_skips_silently", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+		cmd := &WifiSyncCmd{
+			ConfigureBaseCmd: ConfigureBaseCmd{
+				AMTBaseCmd: commands.AMTBaseCmd{
+					WSMan: mockWSMAN,
+				},
+			},
+			OSWiFiSync:   true,
+			UEFIWiFiSync: true,
+		}
+
+		ctx := &commands.Context{AMTPassword: "test-pass"}
+
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiAbsentPorts, nil)
+
+		err := cmd.Run(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ethernet_probe_failure_bubbles_up", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+		cmd := &WifiSyncCmd{
+			ConfigureBaseCmd: ConfigureBaseCmd{
+				AMTBaseCmd: commands.AMTBaseCmd{
+					WSMan: mockWSMAN,
+				},
+			},
+			OSWiFiSync:   true,
+			UEFIWiFiSync: true,
+		}
+
+		ctx := &commands.Context{AMTPassword: "test-pass"}
+
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(nil, errors.New("LMS not reachable"))
+
+		err := cmd.Run(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to detect WiFi hardware")
+		assert.Contains(t, err.Error(), "LMS not reachable")
 	})
 }

--- a/internal/commands/configure/wireless.go
+++ b/internal/commands/configure/wireless.go
@@ -138,6 +138,17 @@ func (cmd *WirelessCmd) Run(ctx *commands.Context) error {
 		return err
 	}
 
+	hasWiFi, err := hasWiFiHardware(cmd.WSMan)
+	if err != nil {
+		return fmt.Errorf("failed to detect WiFi hardware: %w", err)
+	}
+
+	if !hasWiFi {
+		log.Warn("Device does not have WiFi hardware; skipping wireless profile configuration")
+
+		return nil
+	}
+
 	if cmd.Purge {
 		log.Info("purging all AMT wireless profiles")
 
@@ -186,7 +197,7 @@ func (cmd *WirelessCmd) Run(ctx *commands.Context) error {
 	utils.Pause(1)
 
 	// Add WiFi settings via WSMAN
-	_, err := cmd.WSMan.AddWiFiSettings(wifiEndpointSettings, ieee8021xSettings, "WiFi Endpoint 0", handles.ClientCertHandle, handles.RootCertHandle)
+	_, err = cmd.WSMan.AddWiFiSettings(wifiEndpointSettings, ieee8021xSettings, "WiFi Endpoint 0", handles.ClientCertHandle, handles.RootCertHandle)
 	if err != nil {
 		log.Errorf("failed configuring: %s", cmd.ProfileName)
 

--- a/internal/commands/configure/wireless_test.go
+++ b/internal/commands/configure/wireless_test.go
@@ -21,6 +21,47 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func TestWirelessCmd_Run_NoWiFiHardware(t *testing.T) {
+	t.Run("no_wifi_hardware_skips_silently", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+		cmd := &WirelessCmd{
+			ConfigureBaseCmd: ConfigureBaseCmd{
+				AMTBaseCmd: commands.AMTBaseCmd{WSMan: mockWSMAN},
+			},
+			Purge: true,
+		}
+
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(wifiAbsentPorts, nil)
+
+		err := cmd.Run(&commands.Context{AMTPassword: "test-pass"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("ethernet_probe_failure_bubbles_up", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWSMAN := mock.NewMockWSMANer(ctrl)
+
+		cmd := &WirelessCmd{
+			ConfigureBaseCmd: ConfigureBaseCmd{
+				AMTBaseCmd: commands.AMTBaseCmd{WSMan: mockWSMAN},
+			},
+			Purge: true,
+		}
+
+		mockWSMAN.EXPECT().GetEthernetSettings().Return(nil, errors.New("LMS not reachable"))
+
+		err := cmd.Run(&commands.Context{AMTPassword: "test-pass"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to detect WiFi hardware")
+	})
+}
+
 func TestWirelessCmd_Validate(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
RPC-go log : 

```
time="2026-04-16T14:27:11-07:00" level=info msg="AMT Features configured successfully"
time="2026-04-16T14:27:11-07:00" level=info msg="Executing wired network configuration"
time="2026-04-16T14:27:11-07:00" level=info msg="TLS is enforced on local ports"
time="2026-04-16T14:27:12-07:00" level=info msg="Configuring wired ethernet settings..."
time="2026-04-16T14:27:15-07:00" level=info msg="Wired settings configured successfully"
time="2026-04-16T14:27:15-07:00" level=info msg="Executing WiFi sync configuration"
time="2026-04-16T14:27:15-07:00" level=info msg="TLS is enforced on local ports"
time="2026-04-16T14:27:17-07:00" level=warning msg="Device does not have WiFi hardware; skipping WiFi sync configuration"
time="2026-04-16T14:27:17-07:00" level=info msg="Purging existing AMT wireless profiles before applying new configuration"
time="2026-04-16T14:27:17-07:00" level=info msg="TLS is enforced on local ports"
time="2026-04-16T14:27:19-07:00" level=warning msg="Device does not have WiFi hardware; skipping wireless profile configuration"
time="2026-04-16T14:27:19-07:00" level=info msg="No wireless profiles specified in profile; nothing more to apply after purge"
time="2026-04-16T14:27:19-07:00" level=info msg="TLS not enabled, skipping TLS configuration"
```