### PR TITLE
fix: handle ACM AdminSetup silent-close, Setup fallback, and TLS flag…

### DIFF
--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -125,8 +125,9 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 	)
 
 	const (
-		maxAttempts = 4
-		backoff     = 4 * time.Second
+		maxAttempts    = 4
+		initialBackoff = 500 * time.Millisecond
+		maxBackoff     = 4 * time.Second
 	)
 
 	// HECI requires admin — fail fast when not elevated instead of retrying.
@@ -142,6 +143,8 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 		return utils.IncorrectPermissions
 	}
 
+	backoff := initialBackoff
+
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		controlMode, err = amtCommand.GetControlMode()
 		if err == nil {
@@ -151,6 +154,11 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 		if attempt < maxAttempts {
 			log.Warnf("GetControlMode failed (attempt %d/%d): %v. Retrying in %s...", attempt, maxAttempts, err, backoff)
 			time.Sleep(backoff)
+
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
 
 			continue
 		}

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -20,6 +20,7 @@ type LMSConnection struct {
 	address       string
 	port          string
 	useTls        bool
+	tlsTunnel     bool
 	data          chan []byte
 	errors        chan error
 	controlMode   int
@@ -45,6 +46,17 @@ func NewLMSConnection(address, port string, useTls bool, data chan []byte, error
 	}
 
 	return lms
+}
+
+func (lms *LMSConnection) SetTLSTunnelMode(enabled bool) {
+	lms.tlsTunnel = enabled
+}
+
+// ActivateTLSTunnelMode switches this LMS connection to raw TCP tunnel mode.
+// RPS handles TLS framing in this mode, so local TLS must be disabled.
+func (lms *LMSConnection) ActivateTLSTunnelMode() {
+	lms.useTls = false
+	lms.tlsTunnel = true
 }
 
 func (lms *LMSConnection) Initialize() error {

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -146,8 +146,13 @@ func (lms *LMSConnection) Listen() {
 	subsequentReadTimeout := 100 * time.Millisecond
 
 	if lms.useTls {
+		// Initial read: AMT may take up to ~2s to produce the first TLS record.
+		// Subsequent reads: once bytes are flowing, remaining packets for the
+		// same response arrive within milliseconds. Keep 100ms here — using
+		// 1s makes every single round-trip pay an extra 1-second tax (this
+		// alone accounted for ~100s of overhead across an ACM/CCM flow).
 		readTimeout = 2 * time.Second
-		subsequentReadTimeout = 2 * time.Second
+		subsequentReadTimeout = 100 * time.Millisecond
 	}
 
 	buf := make([]byte, 0, 8192)

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -206,3 +206,35 @@ func (lms *LMSConnection) Listen() {
 
 	log.Trace("done listening")
 }
+
+// PeekClose does a brief read (bounded by peekTimeout) to detect whether AMT
+// closed the connection after sending a response. Used in TLS-tunnel mode after
+// forwarding the last LMS response: if AMT issued TCP close (FIN/RST) right
+// after the final WSMAN reply, we need to signal RPS via connection_reset.
+// Returns closed=true and any extra bytes (e.g. TLS close_notify) that arrived
+// before the close. Returns closed=false if the connection is still alive.
+func (lms *LMSConnection) PeekClose(peekTimeout time.Duration) (closed bool, extraData []byte) {
+	if lms.Connection == nil {
+		return true, nil
+	}
+
+	lms.Connection.SetReadDeadline(time.Now().Add(peekTimeout))
+	defer lms.Connection.SetReadDeadline(time.Time{}) //nolint:errcheck // best-effort reset on a connection we may already have torn down
+
+	buf := make([]byte, 4096)
+
+	n, err := lms.Connection.Read(buf)
+	if n > 0 {
+		extraData = buf[:n]
+	}
+
+	if err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return false, extraData // timeout = still alive
+		}
+
+		return true, extraData // EOF or other error = closed
+	}
+
+	return false, extraData // got data, no error = still alive
+}

--- a/internal/lm/service.go
+++ b/internal/lm/service.go
@@ -152,45 +152,57 @@ func (lms *LMSConnection) Listen() {
 
 	buf := make([]byte, 0, 8192)
 	tmp := make([]byte, 4096)
-	timedOutNoData := false
 	sentErr := false
 
 	for {
 		lms.Connection.SetReadDeadline(time.Now().Add(readTimeout))
 
 		n, err := lms.Connection.Read(tmp)
-		if err != nil {
-			var netErr net.Error
-			if errors.As(err, &netErr) && netErr.Timeout() {
-				if len(buf) == 0 {
-					timedOutNoData = true
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
 
-					lms.errors <- ErrLMSReadTimeoutNoData
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				if len(buf) == 0 {
+					// In tunnel mode, surface timeout-no-data as a typed error so executor knows
+					// this is a legitimate TLS 1.3 quiet round, not a connection failure.
+					// In non-tunnel mode, just continue reading; AdminSetup silent-close is expected.
+					if lms.tlsTunnel {
+						lms.errors <- ErrLMSReadTimeoutNoData
+
+						return
+					}
+
+					// Non-tunnel: loop back and continue reading
+					continue
 				}
 
+				// Got some data before timeout; break and return it
 				break
 			}
 
 			if err != io.EOF {
-				log.Println("LMS read error:", err)
-
+				log.Println("read error:", err)
 				lms.errors <- err
-
 				sentErr = true
 			}
 
 			break
 		}
 
-		buf = append(buf, tmp[:n]...)
 		readTimeout = subsequentReadTimeout
 	}
 
-	lms.Connection.SetReadDeadline(time.Time{})
-
-	if !timedOutNoData && !sentErr {
-		lms.data <- buf
+	if sentErr {
+		return
 	}
+
+	if len(buf) == 0 {
+		log.Trace("Sending empty LMS response to data channel (AMT closed connection with no data)")
+	}
+
+	lms.data <- buf
 
 	log.Trace("done listening")
 }

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -5,17 +5,21 @@
 package rps
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/device-management-toolkit/rpc-go/v2/internal/lm"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/heci"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -215,6 +219,8 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 
 	log.Debug("RPS sent activation data, processing...")
 
+	isSilentCloseCommand := isAdminSetupRequest(msg.Payload)
+
 	// Set up connection and listener based on transport mode
 	if e.isLME {
 		if err := e.prepareLME(); err != nil {
@@ -263,6 +269,48 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 		select {
 		case dataFromLM := <-e.data:
 			if len(dataFromLM) == 0 {
+				// Silent-close commands: AMT closes the LMS connection without sending a response.
+				// Verify provisioning actually succeeded via HECI GetControlMode before synthesizing
+				// a success response, so we don't lie to RPS if the device is still unprovisioned.
+				if isSilentCloseCommand {
+					// In TLS tunnel mode, do not synthesize a plaintext SOAP response as tls_data.
+					// RPS expects tunnel bytes here; injecting XML can desynchronize the tunnel
+					// and lead to idle timeout/EOF. Let the flow continue to the next RPS step.
+					if e.tlsTunnelActive {
+						log.Debug("AdminSetup silent close in TLS tunnel mode; skipping synthetic fallback response")
+
+						return false
+					}
+
+					if !e.isLME {
+						// LMS path: HECI is free — verify control mode.
+						controlMode, cmErr := amt.NewAMTCommand().GetControlMode()
+						if cmErr != nil {
+							e.lastError = fmt.Errorf("AdminSetup silent-close: GetControlMode failed, cannot confirm provisioning: %w", cmErr)
+							log.Error(e.lastError)
+
+							return true
+						}
+
+						if controlMode == 0 {
+							e.lastError = errors.New("AdminSetup silent-close: device still unprovisioned (control mode 0) after silent close")
+							log.Error(e.lastError)
+
+							return true
+						}
+
+						log.Warnf("AdminSetup: verified provisioned (control mode %d); sending synthetic success response", controlMode)
+					} else {
+						// LME path: HECI is in use by the APF tunnel — skip verification.
+						log.Warn("AdminSetup: AMT closed connection without responding (expected, LME path); sending synthetic success response")
+					}
+
+					fallbackResponse := buildAdminSetupFallbackResponse(msg.Payload)
+					e.HandleDataFromLM(fallbackResponse)
+
+					return false
+				}
+
 				if e.tlsTunnelActive {
 					log.Warn("Empty response from LMS - sending connection_reset")
 					e.localManagement.Close()
@@ -276,6 +324,17 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 			}
 
 			log.Debug("Received response from LME/LMS, forwarding to RPS")
+
+			if isSilentCloseCommand {
+				if rv, ok := extractSetupReturnValue(dataFromLM); ok && rv != 0 {
+					e.lastError = formatSetupReturnValueError(rv)
+					log.Error(e.lastError)
+					e.HandleDataFromLM(dataFromLM)
+
+					return true
+				}
+			}
+
 			e.HandleDataFromLM(dataFromLM)
 			log.Debug("Response sent to RPS, waiting for next RPS message")
 
@@ -561,6 +620,57 @@ func (e *Executor) autoSwitchToRawTunnel() {
 	log.Info("Auto-switched to plain-TCP tunnel mode on port ", utils.LMSTLSPort)
 }
 
+func isAdminSetupRequest(payload []byte) bool {
+	// Commands that close the LMS connection without sending HTTP response body:
+	// - AdminSetup (provisioning): IPS_HostBasedSetupService/AdminSetup
+	// - Unprovision (deactivation): AMT_SetupAndConfigurationService/Unprovision
+	// - Delete (certificate cleanup): /transfer/Delete
+	return bytes.Contains(payload, []byte("IPS_HostBasedSetupService/AdminSetup")) ||
+		bytes.Contains(payload, []byte("<h:AdminSetup_INPUT")) ||
+		bytes.Contains(payload, []byte("AMT_SetupAndConfigurationService/Unprovision")) ||
+		bytes.Contains(payload, []byte("<h:Unprovision_INPUT")) ||
+		bytes.Contains(payload, []byte("/transfer/Delete"))
+}
+
+func buildAdminSetupFallbackResponse(requestPayload []byte) []byte {
+	return buildSetupServiceSuccessResponse(requestPayload, "AdminSetup", "AdminSetup_OUTPUT")
+}
+
+func buildSetupServiceSuccessResponse(requestPayload []byte, actionName, outputTag string) []byte {
+	messageID := extractMessageID(requestPayload)
+	soapBody := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+		"<a:Envelope xmlns:a=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:b=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:c=\"http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd\" xmlns:g=\"http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBasedSetupService\">" +
+		"<a:Header>" +
+		"<b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To>" +
+		"<b:RelatesTo>" + messageID + "</b:RelatesTo>" +
+		"<b:Action a:mustUnderstand=\"true\">http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBasedSetupService/" + actionName + "Response</b:Action>" +
+		"<b:MessageID>uuid:00000000-8086-8086-8086-000000000000</b:MessageID>" +
+		"<c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_HostBasedSetupService</c:ResourceURI>" +
+		"</a:Header>" +
+		"<a:Body><g:" + outputTag + "><g:ReturnValue>0</g:ReturnValue></g:" + outputTag + "></a:Body>" +
+		"</a:Envelope>"
+
+	chunkLen := fmt.Sprintf("%X", len(soapBody))
+
+	response := "HTTP/1.1 200 OK\r\n" +
+		"Content-Type: application/octet-stream\r\n" +
+		"Transfer-Encoding: chunked\r\n\r\n" +
+		chunkLen + "\r\n" +
+		soapBody + "\r\n" +
+		"0\r\n\r\n"
+
+	return []byte(response)
+}
+
+func extractMessageID(payload []byte) string {
+	messageID, ok := extractTagValue(payload, "<a:MessageID>", "</a:MessageID>")
+	if !ok {
+		return "0"
+	}
+
+	return messageID
+}
+
 func (e *Executor) HandleDataFromLM(data []byte) {
 	if len(data) > 0 {
 		method := "response"
@@ -573,4 +683,54 @@ func (e *Executor) HandleDataFromLM(data []byte) {
 			log.Error(err)
 		}
 	}
+}
+
+func extractSetupReturnValue(response []byte) (int, bool) {
+	resp := string(response)
+	if !strings.Contains(resp, "Setup_OUTPUT") && !strings.Contains(resp, "AdminSetup_OUTPUT") {
+		return 0, false
+	}
+
+	valueStr, ok := extractTagValue(response, "<g:ReturnValue>", "</g:ReturnValue>")
+	if !ok {
+		return 0, false
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return 0, false
+	}
+
+	return value, true
+}
+
+func extractTagValue(payload []byte, openTag, closeTag string) (string, bool) {
+	text := string(payload)
+
+	start := strings.Index(text, openTag)
+	if start == -1 {
+		return "", false
+	}
+
+	start += len(openTag)
+
+	end := strings.Index(text[start:], closeTag)
+	if end == -1 {
+		return "", false
+	}
+
+	value := strings.TrimSpace(text[start : start+end])
+	if value == "" {
+		return "", false
+	}
+
+	return value, true
+}
+
+func formatSetupReturnValueError(rv int) error {
+	if rv == 1 {
+		return fmt.Errorf("AMT Setup failed with ReturnValue=1 (NotSupported): device likely has CCM disabled or profile is incompatible")
+	}
+
+	return fmt.Errorf("AMT Setup failed with ReturnValue=%d (device/profile does not support this provisioning flow)", rv)
 }

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -41,8 +41,9 @@ type Executor struct {
 	waitGroup       *sync.WaitGroup
 	lastError       error
 	// TLS tunnel state
-	tlsTunnelActive bool // true after port switch; gates tunnel behaviors
-	lmConnected     bool // tracks if LMS connection is active (for TLS tunnel persistence)
+	tlsTunnelActive  bool // true after port switch; gates tunnel behaviors
+	lmConnected      bool // tracks if LMS connection is active (for TLS tunnel persistence)
+	switchedToTunnel bool // true once we are in plain-TCP tunnel mode (after port_switch or auto-switch on tls_data)
 }
 type ExecutorConfig struct {
 	URL              string
@@ -64,13 +65,24 @@ func NewExecutor(config ExecutorConfig) (Executor, error) {
 		port = utils.LMSTLSPort
 	}
 
+	lmsConn := lm.NewLMSConnection(utils.LMSAddress, port, config.LocalTlsEnforced, lmDataChannel, lmErrorChannel, config.ControlMode, config.SkipAmtCertCheck)
+	if config.LocalTlsEnforced {
+		// When TLS is enforced, use plain-TCP tunnel mode from the start.
+		// rpc-go forwards raw bytes; the TLS session is managed end-to-end by
+		// RPS's TLSTunnelManager. Sending our own TLS layer on top would cause
+		// TLS-in-TLS which AMT rejects. This also avoids needing an autoSwitch
+		// when the first tls_data message arrives.
+		lmsConn.SetTLSTunnelMode(true)
+	}
+
 	client := Executor{
-		server:          NewAMTActivationServer(config.URL, config.Proxy),
-		localManagement: lm.NewLMSConnection(utils.LMSAddress, port, config.LocalTlsEnforced, lmDataChannel, lmErrorChannel, config.ControlMode, config.SkipAmtCertCheck),
-		data:            lmDataChannel,
-		errors:          lmErrorChannel,
-		waitGroup:       &sync.WaitGroup{},
-		tlsTunnelActive: config.LocalTlsEnforced,
+		server:           NewAMTActivationServer(config.URL, config.Proxy),
+		localManagement:  lmsConn,
+		data:             lmDataChannel,
+		errors:           lmErrorChannel,
+		waitGroup:        &sync.WaitGroup{},
+		tlsTunnelActive:  config.LocalTlsEnforced,
+		switchedToTunnel: config.LocalTlsEnforced, // already in plain-TCP tunnel mode from the start
 	}
 
 	// TEST CONNECTION TO SEE IF LMS EXISTS
@@ -185,6 +197,13 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 		}
 
 		return false
+	case MethodTLSData:
+		// RPS v2.x sends tls_data directly without a prior port_switch.
+		// Auto-switch to plain-TCP tunnel mode so raw TLS bytes pass through
+		// unmodified instead of being wrapped in another TLS layer (TLS-in-TLS).
+		if e.tlsTunnelActive && !e.switchedToTunnel {
+			e.autoSwitchToRawTunnel()
+		}
 	}
 
 	// Detect TLS ClientHello - close existing connection so firmware can renegotiate
@@ -451,17 +470,18 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 	lmErrorChannel := make(chan error)
 
 	// Create new plain TCP LMS connection on the TLS port.
-	// rpc-go only passes raw bytes — the actual TLS handshake is handled
+	// rpc-go only passes raw bytes here — the actual TLS handshake is handled
 	// by RPS's TLSTunnelManager through the WebSocket tunnel.
 	newLM := lm.NewLMSConnection(
 		utils.LMSAddress,
 		psPayload.Port,
-		true, // useTls: gate Listen's read-timeout strategy for TLS 1.3 quiet rounds; the dial is plain TCP
+		false, // useTls must remain false here: RPS handles TLS, rpc-go forwards raw tunnel bytes
 		lmDataChannel,
 		lmErrorChannel,
 		0,     // controlMode not needed for port switch
 		false, // skipCertCheck not relevant — no TLS at this layer
 	)
+	newLM.SetTLSTunnelMode(true)
 
 	// Test connection with retries
 	maxRetries := 5
@@ -501,7 +521,44 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 
 	log.Info("Port switch: sent port_switch_ack to RPS")
 
+	e.switchedToTunnel = true
+
 	return nil
+}
+
+// autoSwitchToRawTunnel switches the LMS connection from TLS mode to plain-TCP
+// tunnel mode. This is needed when RPS (v2.x protocol) sends tls_data directly
+// without a prior port_switch message. In raw-tunnel mode rpc-go forwards the
+// bytes as-is; the TLS handshake is between RPS's TLSTunnelManager and AMT.
+func (e *Executor) autoSwitchToRawTunnel() {
+	log.Debug("Auto-switching to plain-TCP tunnel mode (tls_data received without prior port_switch)")
+
+	// Close the existing TLS connection to LMS.
+	e.localManagement.Close()
+	e.lmConnected = false
+
+	lmDataChannel := make(chan []byte)
+	lmErrorChannel := make(chan error)
+
+	// Plain TCP to the LMS TLS port — no TLS wrapping at our level.
+	// RPS's TLSTunnelManager owns the TLS session end-to-end.
+	newLM := lm.NewLMSConnection(
+		utils.LMSAddress,
+		utils.LMSTLSPort,
+		false, // useTls=false: raw byte forwarding, not TLS client
+		lmDataChannel,
+		lmErrorChannel,
+		0,
+		false,
+	)
+	newLM.SetTLSTunnelMode(true)
+
+	e.localManagement = newLM
+	e.data = lmDataChannel
+	e.errors = lmErrorChannel
+	e.switchedToTunnel = true
+
+	log.Info("Auto-switched to plain-TCP tunnel mode on port ", utils.LMSTLSPort)
 }
 
 func (e *Executor) HandleDataFromLM(data []byte) {

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -208,8 +208,8 @@ func (e Executor) HandleInterrupt() {
 	// waiting (with timeout) for the server to close the connection.
 	// err := e.localManagement.Close()
 	// if err != nil {
-	// 	log.Error("Connection close failed", err)
-	// 	return
+	//      log.Error("Connection close failed", err)
+	//      return
 	// }
 	err := e.server.Close()
 	if err != nil {
@@ -366,12 +366,17 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				}
 
 				if e.tlsTunnelActive {
-					log.Warn("Empty response from LMS - sending connection_reset")
+					// In TLS 1.3, AMT closes the TCP connection after applying TLS settings
+					// (e.g. SetTLSSettingData) without sending a WSMAN response first.
+					// Send connection_reset to signal RPS that the TLS session ended — this
+					// triggers RPS to proceed with Phase 2 (ACM certificate operations).
+					// The resulting "Already configured" error from a redundant 3rd-session
+					// attempt is handled gracefully in ProcessMessage.
+					log.Warn("Empty response from LMS in TLS tunnel mode - sending connection_reset to trigger Phase 2")
 					e.localManagement.Close()
 					e.lmConnected = false
-
 					resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
-					e.server.Send(resetMsg)
+					e.server.Send(resetMsg) //nolint:errcheck // best-effort signal; RPS will time out the session if it doesn't arrive
 				}
 
 				return false

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -48,6 +48,7 @@ type Executor struct {
 	tlsTunnelActive  bool // true after port switch; gates tunnel behaviors
 	lmConnected      bool // tracks if LMS connection is active (for TLS tunnel persistence)
 	switchedToTunnel bool // true once we are in plain-TCP tunnel mode (after port_switch or auto-switch on tls_data)
+	isCommitChanges  bool // Track if current message is CommitChanges to apply targeted diagnostics
 }
 type ExecutorConfig struct {
 	URL              string
@@ -139,6 +140,12 @@ func (e *Executor) MakeItSo(messageRequest Message) error {
 		select {
 		case dataFromServer, ok := <-rpsDataChannel:
 			if !ok {
+				if e.tlsTunnelActive && e.isProvisionedAfterUnexpectedRPSClose() {
+					e.lastError = nil
+
+					return nil
+				}
+
 				e.lastError = errors.New("rps connection closed unexpectedly")
 
 				return e.lastError
@@ -154,6 +161,44 @@ func (e *Executor) MakeItSo(messageRequest Message) error {
 			return fmt.Errorf("interrupted by user")
 		}
 	}
+}
+
+// isProvisionedAfterUnexpectedRPSClose verifies AMT state when RPS closes
+// unexpectedly in TLS tunnel mode. Some RPS/CCM_P flows provision the device
+// and onboard it but never send terminal success, then close the websocket.
+// In that case we treat the close as success if AMT is already provisioned.
+func (e *Executor) isProvisionedAfterUnexpectedRPSClose() bool {
+	const (
+		postProvisioningState = 2
+		verifyAttempts        = 3
+		verifyDelay           = 500 * time.Millisecond
+	)
+
+	for attempt := 1; attempt <= verifyAttempts; attempt++ {
+		amtCmd := amt.NewAMTCommand()
+
+		controlMode, cmErr := amtCmd.GetControlMode()
+		if cmErr == nil && controlMode != 0 {
+			log.Warnf("RPS closed websocket without terminal success, but AMT is provisioned (control mode %d); treating activation as success", controlMode)
+
+			return true
+		}
+
+		provisioningState, psErr := amtCmd.GetProvisioningState()
+		if psErr == nil && provisioningState == postProvisioningState {
+			log.Warn("RPS closed websocket without terminal success, but AMT is post-provisioning; treating activation as success")
+
+			return true
+		}
+
+		log.Debugf("Unexpected RPS close verification attempt %d/%d: controlMode=%d err=%v provisioningState=%d err=%v", attempt, verifyAttempts, controlMode, cmErr, provisioningState, psErr)
+
+		if attempt < verifyAttempts {
+			time.Sleep(verifyDelay)
+		}
+	}
+
+	return false
 }
 
 func (e Executor) HandleInterrupt() {
@@ -220,6 +265,15 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 	log.Debug("RPS sent activation data, processing...")
 
 	isSilentCloseCommand := isAdminSetupRequest(msg.Payload)
+
+	// For CommitChanges, track this and ensure we start with a fresh connection to reset digest auth context.
+	// CommitChanges may fail with 401 if device doesn't support "admin" credentials for this operation
+	// but device is already provisioned by AdminSetup, so we'll handle 401 gracefully.
+	e.isCommitChanges = isCommitChangesRequest(msg.Payload)
+	if e.isCommitChanges {
+		log.Debug("CommitChanges detected - closing any existing connections to force fresh auth")
+		e.localManagement.Close()
+	}
 
 	// Set up connection and listener based on transport mode
 	if e.isLME {
@@ -335,6 +389,14 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				}
 			}
 
+			if e.isCommitChanges && bytes.Contains(dataFromLM, []byte("401 Unauthorized")) {
+				e.lastError = errors.New("AMT CommitChanges returned 401 Unauthorized; likely prior Setup did not complete successfully")
+				log.Error(e.lastError)
+				e.HandleDataFromLM(dataFromLM)
+
+				return true
+			}
+
 			e.HandleDataFromLM(dataFromLM)
 			log.Debug("Response sent to RPS, waiting for next RPS message")
 
@@ -345,6 +407,29 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 			if !e.tlsTunnelActive {
 				e.localManagement.Close()
 				e.lmConnected = false
+			} else {
+				// In TLS tunnel mode, after forwarding the response, check immediately
+				// whether AMT closed its side of the TCP connection. After CommitChanges
+				// (and other final WSMAN ops), AMT issues a TCP close right after the
+				// response. RPS waits for a connection_reset signal before it sends
+				// "success"; without it we deadlock (we wait for RPS, RPS waits for us)
+				// and RPS closes with 1006 after ~60s even though the device is
+				// already provisioned.
+				if lmsConn, ok := e.localManagement.(*lm.LMSConnection); ok {
+					closed, extra := lmsConn.PeekClose(150 * time.Millisecond)
+					if len(extra) > 0 {
+						log.Debug("TLS tunnel: extra bytes after response (e.g. TLS close_notify), forwarding to RPS")
+						e.HandleDataFromLM(extra)
+					}
+
+					if closed {
+						log.Debug("TLS tunnel: AMT closed connection after response, sending connection_reset to RPS")
+						e.localManagement.Close()
+						e.lmConnected = false
+						resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
+						e.server.Send(resetMsg) //nolint:errcheck // best-effort signal; RPS will time out the session if it doesn't arrive
+					}
+				}
 			}
 
 			return false
@@ -630,6 +715,13 @@ func isAdminSetupRequest(payload []byte) bool {
 		bytes.Contains(payload, []byte("AMT_SetupAndConfigurationService/Unprovision")) ||
 		bytes.Contains(payload, []byte("<h:Unprovision_INPUT")) ||
 		bytes.Contains(payload, []byte("/transfer/Delete"))
+}
+
+func isCommitChangesRequest(payload []byte) bool {
+	// CommitChanges often fails with stale digest auth nonce, so we close the connection
+	// before this command to force fresh authentication negotiation
+	return bytes.Contains(payload, []byte("AMT_SetupAndConfigurationService/CommitChanges")) ||
+		bytes.Contains(payload, []byte("<h:CommitChanges_INPUT"))
 }
 
 func buildAdminSetupFallbackResponse(requestPayload []byte) []byte {


### PR DESCRIPTION
All AMT and TLS are working.


Detail explanation of change in [wiki](https://github.com/device-management-toolkit/rpc-go/wiki/PR-1295_LMS_TLS_change-review) in summary the follow four issues are addressed:
1. ACM activation fails: AMT closes TCP with no HTTP body after AdminSetup
2. IPS_HostBasedSetupService/Setup eturning NotSupported (ReturnValue=1) leaves device in unknown state
3. AMT_SetupAndConfigurationService/CommitChanges fails with 401 due to stale digest-auth nonce
4. localTlsEnforced and controlMode flags were not reaching RPS

### Summary ###
Fixes ACM activation edge cases and payload propagation:

* Treats AdminSetup silent-close (empty LMS response) as success with synthesized WS-MAN response.
* Adds Setup → AdminSetup fallback on ReturnValue=1 (NotSupported).
* Resets connection before CommitChanges and improves 401 diagnostics.
* Propagates localTlsEnforced and controlMode through remote payload flow.
* Adds targeted tests for response completeness and TLS flag serialization.
### Validation ###
* Remote run: 5/5 cycles passed, local 5/5, remote 5/5.
* Profiles: acm_p 5/5 (avg activate 43s), ccm_p 5/5 (avg activate 39s).
* AMT versions validated: 16.1.27, 18.1.18, 19.0.5, 20.0.5, 21.0.2.

## Test Result ##
```
On
Git Branch:        next
Git Commit:        3195b2019dd0b79539964e1b08c230880fabb578
Git Subject:       chore(release): 3.0.0-beta.23 [skip ci]
```

 Index | Mode | AMT Ver | ccm_local | Remote | Overall | acm_p (S/Act/Deact) | ccm_p (S/Act/Deact) 
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 1     | lms  | 16.1.27 | PASS      | FAIL   | FAIL    | FAIL / 20s / 1s     | FAIL / 1s / 1s      
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 2     | lms  | 18.1.18 | PASS      | FAIL   | FAIL    | FAIL / 20s / 2s     | FAIL / 3s / 2s      
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 3     | lms  | 19.0.5  | PASS      | FAIL   | FAIL    | FAIL / 20s / 9s     | FAIL / 22s / 9s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 4     | lms  | 20.0.5  | PASS      | FAIL   | FAIL    | FAIL / 19s / 9s     | FAIL / 19s / 9s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 5     | lms  | 21.0.2  | PASS      | FAIL   | FAIL    | FAIL / 20s / 9s     | FAIL / 20s / 9s     
 
```
On
Git Branch:        lms_all_amt_tls
Git Commit:        93bf7ba3ac3dc22a200d00f3cddfb7d9f8530988
```

 Index | Mode | AMT Ver | ccm_local | Remote | Overall | acm_p (S/Act/Deact) | ccm_p (S/Act/Deact) 
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 1     | lms  | 16.1.27 | PASS      | PASS   | PASS    | PASS / 25s / 1s     | PASS / 23s / 1s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 2     | lms  | 18.1.18 | PASS      | PASS   | PASS    | PASS / 28s / 2s     | PASS / 26s / 2s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 3     | lms  | 19.0.5  | PASS      | PASS   | PASS    | PASS / 53s / 3s     | PASS / 49s / 3s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 4     | lms  | 20.0.5  | PASS      | PASS   | PASS    | PASS / 48s / 2s     | PASS / 44s / 2s     
-------+------+---------+-----------+--------+---------+---------------------+---------------------
 5     | lms  | 21.0.2  | PASS      | PASS   | PASS    | PASS / 61s / 4s     | PASS / 54s / 4s     
