### PR TITLE
chore: create FreeString method in lib.go and update go to the latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         os: [windows-2022, ubuntu-22.04, ubuntu-24.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/cmd/rpc/lib.go
+++ b/cmd/rpc/lib.go
@@ -7,6 +7,9 @@ package main
 // NOTE: this file is designed to be built into a C library and the import
 // of 'C' introduces a dependency on the gcc toolchain
 
+/*
+#include <stdlib.h>
+*/
 import "C"
 
 import (
@@ -16,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unsafe"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -153,6 +157,11 @@ func rpcExec(Input *C.char, Output **C.char) int {
 	}
 
 	return int(utils.Success)
+}
+
+//export FreeString
+func FreeString(s *C.char) {
+	C.free(unsafe.Pointer(s))
 }
 
 func handleError(err error) int {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/device-management-toolkit/rpc-go/v2
 
-go 1.25.0
+go 1.26.0
 
 // uncomment if developing with go-wsman-messages locally
 // replace github.com/device-management-toolkit/go-wsman-messages/v2 => ../go-wsman-messages


### PR DESCRIPTION
RPC library is updated to expose a method to free the memory and updated go version to fix security vulnerabilities.
Here is the documentation about the vulnerabilities in **go 1.25** :
  - https://nvd.nist.gov/vuln/detail/CVE-2026-27143 NVD - CVE-2026-27143
  - https://nvd.nist.gov/vuln/detail/CVE-2026-27144 NVD - CVE-2026-27144