### PR TITLE
fix: bump Go version to 1.26.3 to address CVE-2026-27143

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25']
+        go-version: ['1.26']
     
     steps:
       - name: Harden Runner
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25']
+        go-version: ['1.26']
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        go-version: [1.25]
+        go-version: [1.26]
         os: [windows-2022, ubuntu-22.04, ubuntu-24.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/device-management-toolkit/rpc-go/v2
 
-go 1.25.0
+go 1.26.3
 
 // uncomment when developing locally
 // replace github.com/device-management-toolkit/go-wsman-messages/v2 => ../go-wsman-messages


### PR DESCRIPTION
Arithmetic over induction variables in loops were not correctly checked for underflow or overflow, potentially leading to memory corruption.