### PR TITLE
feat: Enabled ODCA verification for rpc-go

### DIFF
--- a/internal/certs/lmsTls.go
+++ b/internal/certs/lmsTls.go
@@ -5,14 +5,19 @@
 package certs
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/upid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -23,21 +28,30 @@ const (
 	onDieCSMEPrefix  = "On Die CSME"
 )
 
+const (
+	hashAlgorithmSHA256 = "SHA256"
+	hashAlgorithmSHA384 = "SHA384"
+)
+
 // generates a TLS configuration based on the provided mode.
-func GetTLSConfig(mode *int, amtCertInfo *amt.SecureHBasedResponse, skipAMTCertCheck bool) *tls.Config {
+func GetTLSConfig(mode *int, amtCertInfo *amt.SecureHBasedResponse, skipAMTCertCheck bool, upidInfo *upid.UPID) *tls.Config {
 	tlsConfig := &tls.Config{}
 
-	tlsConfig.InsecureSkipVerify = skipAMTCertCheck
-
 	if *mode == 0 { // pre-provisioning mode
+		// Use custom ODCA verification for pre-provisioning TLS.
+		// We must bypass the default verifier so AMT's activation certificate chain
+		// can be validated against the embedded ODCA trust store (without relying on
+		// host OS roots / strict EKU checks).
+		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			if skipAMTCertCheck {
 				return nil
 			}
 
-			return VerifyCertificates(rawCerts, mode, amtCertInfo)
+			return VerifyCertificates(rawCerts, mode, amtCertInfo, upidInfo)
 		}
 	} else {
+		tlsConfig.InsecureSkipVerify = skipAMTCertCheck
 		// default tls config if device is in ACM or CCM
 		log.Trace("Setting default TLS Config for ACM/CCM mode")
 	}
@@ -45,7 +59,7 @@ func GetTLSConfig(mode *int, amtCertInfo *amt.SecureHBasedResponse, skipAMTCertC
 	return tlsConfig
 }
 
-func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBasedResponse) error {
+func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBasedResponse, upidInfo *upid.UPID) error {
 	numCerts := len(rawCerts)
 
 	const (
@@ -55,7 +69,10 @@ func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBa
 		leafLevel             = 0
 	)
 
-	var parsedCerts []*x509.Certificate
+	var (
+		parsedCerts []*x509.Certificate
+		romODCACert *x509.Certificate
+	)
 
 	switch numCerts {
 	case 4:
@@ -69,7 +86,7 @@ func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBa
 				return err
 			}
 
-			log.Infof("Cert[%d]: Subject=%s, Issuer=%s, EKU=%v", i, cert.Subject, cert.Issuer, cert.ExtKeyUsage)
+			log.Debugf("Cert[%d]: Subject=%s, Issuer=%s, EKU=%v", i, cert.Subject, cert.Issuer, cert.ExtKeyUsage)
 
 			parsedCerts = append(parsedCerts, cert)
 
@@ -79,11 +96,23 @@ func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBa
 					return err
 				}
 			case odcaCertLevel:
+				romODCACert = cert
 				if err := VerifyROMODCACertificate(cert.Subject.CommonName, cert.Issuer.OrganizationalUnit); err != nil {
 					return err
 				}
-			} // TODO: verify CRL for each cert
+			}
 		}
+
+		if upidInfo != nil {
+			if romODCACert == nil {
+				return errors.New("failed to identify ROM ODCA certificate for UPID binding verification")
+			}
+
+			if err := VerifyUPIDBinding(romODCACert, upidInfo); err != nil {
+				return err
+			}
+		}
+
 		// verify the full chain
 		if err := VerifyFullChain(parsedCerts); err != nil {
 			return err
@@ -97,6 +126,27 @@ func VerifyCertificates(rawCerts [][]byte, mode *int, amtCertInfo *amt.SecureHBa
 	return errors.New("unexpected number of certificates received from AMT: " + strconv.Itoa(numCerts))
 }
 
+func VerifyUPIDBinding(romODCACert *x509.Certificate, upidInfo *upid.UPID) error {
+	// Per AMT secure host-based verification, UPID HWSerialNum binds to the
+	// first 20 bytes of the SHA-256 hash of the ROM ODCA certificate.
+	const upidBindingPrefixLen = 20
+
+	if romODCACert == nil {
+		return errors.New("ROM ODCA certificate is required for UPID verification")
+	}
+
+	if upidInfo == nil || len(upidInfo.HWSerialNum) < upidBindingPrefixLen {
+		return errors.New("UPID data is unavailable or invalid")
+	}
+
+	romHash := sha256.Sum256(romODCACert.Raw)
+	if !bytes.Equal(romHash[:upidBindingPrefixLen], upidInfo.HWSerialNum[:upidBindingPrefixLen]) {
+		return errors.New("UPID CSME HW ID does not match ROM ODCA certificate hash")
+	}
+
+	return nil
+}
+
 // validate the leaf certificate
 func VerifyLeafCertificate(cn *x509.Certificate, amtCertInfo *amt.SecureHBasedResponse) error {
 	allowedLeafCNs := []string{
@@ -104,10 +154,23 @@ func VerifyLeafCertificate(cn *x509.Certificate, amtCertInfo *amt.SecureHBasedRe
 	}
 
 	if amtCertInfo != nil {
-		hash := sha256.Sum256(cn.Raw)
-		// todo: set length based on algorithm
-		if string(hash[:32]) != amtCertInfo.AMTCertHash[:32] {
-			return errors.New("hashes don't match")
+		normalizedAlgo := strings.ToUpper(strings.TrimSpace(amtCertInfo.HashAlgorithm))
+		if normalizedAlgo == "" {
+			normalizedAlgo = hashAlgorithmSHA256
+		}
+
+		expectedHash, err := decodeAMTCertHash(amtCertInfo.AMTCertHash, normalizedAlgo)
+		if err != nil {
+			return err
+		}
+
+		actualHash, err := computeLeafHash(cn.Raw, normalizedAlgo)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Equal(actualHash, expectedHash) {
+			return fmt.Errorf("leaf certificate hash mismatch (algorithm=%s)", normalizedAlgo)
 		}
 	}
 
@@ -122,6 +185,59 @@ func VerifyLeafCertificate(cn *x509.Certificate, amtCertInfo *amt.SecureHBasedRe
 	return errors.New("leaf certificate CN is not allowed")
 }
 
+func computeLeafHash(certRaw []byte, hashAlgorithm string) ([]byte, error) {
+	switch strings.ToUpper(strings.TrimSpace(hashAlgorithm)) {
+	case "", hashAlgorithmSHA256:
+		hash := sha256.Sum256(certRaw)
+
+		return hash[:], nil
+	case hashAlgorithmSHA384:
+		hash := sha512.Sum384(certRaw)
+
+		return hash[:], nil
+	default:
+		return nil, fmt.Errorf("unsupported AMT hash algorithm: %s", hashAlgorithm)
+	}
+}
+
+func decodeAMTCertHash(rawHash string, hashAlgorithm string) ([]byte, error) {
+	wireHash := []byte(rawHash)
+
+	hashLen, err := hashLengthForAlgorithm(hashAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(wireHash) < hashLen {
+		return nil, errors.New("AMT certificate hash is shorter than expected")
+	}
+
+	// Newer firmware can return ASCII hex (64 chars for SHA-256), while other
+	// paths can expose raw bytes from the fixed-size PTHI array.
+	trimmed := strings.TrimSpace(strings.TrimRight(rawHash, "\x00"))
+	if len(trimmed) == hashLen*2 {
+		decoded, decErr := hex.DecodeString(trimmed)
+		if decErr != nil {
+			return nil, fmt.Errorf("failed to decode AMT certificate hash as hex: %w", decErr)
+		}
+
+		return decoded, nil
+	}
+
+	return wireHash[:hashLen], nil
+}
+
+func hashLengthForAlgorithm(hashAlgorithm string) (int, error) {
+	switch strings.ToUpper(strings.TrimSpace(hashAlgorithm)) {
+	case "", hashAlgorithmSHA256:
+		return sha256.Size, nil
+	case hashAlgorithmSHA384:
+		return sha512.Size384, nil
+	default:
+		return 0, fmt.Errorf("unsupported AMT hash algorithm: %s", hashAlgorithm)
+	}
+}
+
 // validate CSME ROM ODCA certificate
 func VerifyROMODCACertificate(cn string, issuerOU []string) error {
 	allowedOUPrefixes := []string{
@@ -134,7 +250,7 @@ func VerifyROMODCACertificate(cn string, issuerOU []string) error {
 		return errors.New("invalid ROM ODCA Certificate")
 	}
 
-	// check that OU of odcaCertLevel must have a prefix equal to either ODCA 2 CSME P or On Die CSME P
+	// check that OU of odcaCertLevel must have one of the allowed ODCA prefixes
 	for _, ou := range issuerOU {
 		for _, prefix := range allowedOUPrefixes {
 			if strings.HasPrefix(ou, prefix) {

--- a/internal/certs/lmsTls_test.go
+++ b/internal/certs/lmsTls_test.go
@@ -7,15 +7,21 @@ package certs
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"errors"
 	"io/fs"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/upid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,17 +71,72 @@ func createCertTemplate(commonName string, isCA bool, ou []string) *x509.Certifi
 }
 
 func TestGetTLSConfig(t *testing.T) {
-	mode := 0
-	tlsConfig := GetTLSConfig(&mode, nil, true)
-	assert.NotNil(t, tlsConfig)
-	assert.True(t, tlsConfig.InsecureSkipVerify)
-	assert.NotNil(t, tlsConfig.VerifyPeerCertificate)
+	tests := []struct {
+		name                 string
+		mode                 int
+		skip                 bool
+		expectInsecureSkip   bool
+		expectPeerVerifyHook bool
+	}{
+		{
+			name:                 "pre-provisioning with verification enabled",
+			mode:                 0,
+			skip:                 false,
+			expectInsecureSkip:   true,
+			expectPeerVerifyHook: true,
+		},
+		{
+			name:                 "pre-provisioning with verification skipped",
+			mode:                 0,
+			skip:                 true,
+			expectInsecureSkip:   true,
+			expectPeerVerifyHook: true,
+		},
+		{
+			name:                 "ccm-acm with verification enabled",
+			mode:                 1,
+			skip:                 false,
+			expectInsecureSkip:   false,
+			expectPeerVerifyHook: false,
+		},
+		{
+			name:                 "ccm-acm with verification skipped",
+			mode:                 1,
+			skip:                 true,
+			expectInsecureSkip:   true,
+			expectPeerVerifyHook: false,
+		},
+	}
 
-	mode = 1
-	tlsConfig = GetTLSConfig(&mode, nil, true)
-	assert.NotNil(t, tlsConfig)
-	assert.True(t, tlsConfig.InsecureSkipVerify)
-	assert.Nil(t, tlsConfig.VerifyPeerCertificate)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tlsConfig := GetTLSConfig(&tt.mode, nil, tt.skip, nil)
+			assert.NotNil(t, tlsConfig)
+			assert.Equal(t, tt.expectInsecureSkip, tlsConfig.InsecureSkipVerify)
+
+			if tt.expectPeerVerifyHook {
+				assert.NotNil(t, tlsConfig.VerifyPeerCertificate)
+			} else {
+				assert.Nil(t, tlsConfig.VerifyPeerCertificate)
+			}
+		})
+	}
+}
+
+func TestVerifyUPIDBinding(t *testing.T) {
+	romTemplate := createCertTemplate("ROM CA", true, []string{"ODCA 2 CSME P"})
+	romCert, _ := createTestCert(t, romTemplate, nil, nil)
+	romHash := sha256.Sum256(romCert.Raw)
+
+	hwSerial := make([]byte, upid.HWSerialNumSize)
+	copy(hwSerial[:20], romHash[:20])
+
+	matchingUPID := &upid.UPID{HWSerialNum: hwSerial}
+	assert.NoError(t, VerifyUPIDBinding(romCert, matchingUPID))
+
+	hwSerial[0] ^= 0xFF
+	mismatchedUPID := &upid.UPID{HWSerialNum: hwSerial}
+	assert.Error(t, VerifyUPIDBinding(romCert, mismatchedUPID))
 }
 
 func TestVerifyLeafCertificate(t *testing.T) {
@@ -98,6 +159,84 @@ func TestVerifyLeafCertificate(t *testing.T) {
 	}
 }
 
+func TestVerifyLeafCertificate_WithAMTHashValidation(t *testing.T) {
+	leafTemplate := createCertTemplate("iAMT CSME IDevID RCFG", false, []string{"Leaf OU"})
+	leafCert, _ := createTestCert(t, leafTemplate, nil, nil)
+
+	sha256Hash := sha256.Sum256(leafCert.Raw)
+	sha384Hash := sha512.Sum384(leafCert.Raw)
+
+	tests := []struct {
+		name      string
+		amtInfo   *amt.SecureHBasedResponse
+		shouldErr bool
+	}{
+		{
+			name: "accepts SHA256 hex hash from AMT",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "SHA256",
+				AMTCertHash:   strings.ToUpper(hex.EncodeToString(sha256Hash[:])),
+			},
+			shouldErr: false,
+		},
+		{
+			name: "accepts SHA256 raw bytes from AMT buffer",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "SHA256",
+				AMTCertHash:   string(append(sha256Hash[:], make([]byte, 32)...)),
+			},
+			shouldErr: false,
+		},
+		{
+			name: "accepts SHA384 raw bytes from AMT buffer",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "SHA384",
+				AMTCertHash:   string(append(sha384Hash[:], make([]byte, 16)...)),
+			},
+			shouldErr: false,
+		},
+		{
+			name: "rejects mismatched AMT hash",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "SHA256",
+				AMTCertHash:   strings.Repeat("0", 64),
+			},
+			shouldErr: true,
+		},
+		{
+			name: "rejects mismatched hash with empty algorithm and reports SHA256",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "   ",
+				AMTCertHash:   strings.Repeat("0", 64),
+			},
+			shouldErr: true,
+		},
+		{
+			name: "rejects malformed SHA256 hex hash from AMT",
+			amtInfo: &amt.SecureHBasedResponse{
+				HashAlgorithm: "SHA256",
+				AMTCertHash:   strings.Repeat("Z", 64),
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyLeafCertificate(leafCert, tt.amtInfo)
+			if tt.shouldErr {
+				assert.Error(t, err)
+
+				if tt.name == "rejects mismatched hash with empty algorithm and reports SHA256" {
+					assert.ErrorContains(t, err, "algorithm=SHA256")
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestVerifyROMODCACertificate(t *testing.T) {
 	tests := []struct {
 		cn        string
@@ -106,6 +245,7 @@ func TestVerifyROMODCACertificate(t *testing.T) {
 	}{
 		{"ROM CA Cert", []string{"ODCA 2 CSME P"}, false},
 		{"ROM DE Cert", []string{"On Die CSME P"}, false},
+		{"ROM CA Cert", []string{"Invalid OU Prefix"}, true},
 		{"Invalid Cert", []string{"Invalid OU"}, true},
 	}
 
@@ -298,4 +438,95 @@ func TestVerifyFullChain(t *testing.T) {
 			}
 		})
 	}
+}
+
+func buildUPIDBindingTestChain(t *testing.T) ([][]byte, *x509.Certificate, *x509.Certificate) {
+	t.Helper()
+
+	rootTemplate := createCertTemplate("Root CA", true, []string{"Root OU"})
+	rootCert, rootKey := createTestCert(t, rootTemplate, nil, nil)
+
+	lastIntermTemplate := createCertTemplate("Last Intermediate", true, []string{"Last Interim OU"})
+	lastIntermCert, lastIntermKey := createTestCert(t, lastIntermTemplate, rootCert, rootKey)
+
+	// This certificate signs ROM ODCA and provides issuer OU used by VerifyROMODCACertificate.
+	odcaIssuerTemplate := createCertTemplate("ODCA Issuer", true, []string{"ODCA 2 CSME P"})
+	odcaIssuerCert, odcaIssuerKey := createTestCert(t, odcaIssuerTemplate, lastIntermCert, lastIntermKey)
+
+	romODCATemplate := createCertTemplate("ROM CA", true, []string{"ROM OU"})
+	romODCACert, romODCAKey := createTestCert(t, romODCATemplate, odcaIssuerCert, odcaIssuerKey)
+
+	interm2Template := createCertTemplate("Intermediate 2", true, []string{"Intermediate 2 OU"})
+	interm2Cert, interm2Key := createTestCert(t, interm2Template, romODCACert, romODCAKey)
+
+	interm1Template := createCertTemplate("Intermediate 1", true, []string{"Intermediate 1 OU"})
+	interm1Cert, interm1Key := createTestCert(t, interm1Template, interm2Cert, interm2Key)
+
+	leafTemplate := createCertTemplate("iAMT CSME IDevID RCFG", false, []string{"Leaf OU"})
+	leafCert, _ := createTestCert(t, leafTemplate, interm1Cert, interm1Key)
+
+	mockFS := &mockFileSystem{
+		certFiles: []string{"root.cer"},
+		certData:  map[string][]byte{"trustedstore/root.cer": rootCert.Raw},
+	}
+
+	oldLoadRootCAPool := LoadRootCAPool
+	LoadRootCAPool = func() (*x509.CertPool, error) {
+		return LoadRootCAPoolwithFS(mockFS)
+	}
+
+	t.Cleanup(func() {
+		LoadRootCAPool = oldLoadRootCAPool
+	})
+
+	rawCerts := [][]byte{
+		leafCert.Raw,
+		interm1Cert.Raw,
+		interm2Cert.Raw,
+		romODCACert.Raw,
+		odcaIssuerCert.Raw,
+		lastIntermCert.Raw,
+	}
+
+	return rawCerts, leafCert, romODCACert
+}
+
+func TestVerifyCertificates_UPIDBinding_Success(t *testing.T) {
+	mode := 0
+	rawCerts, leafCert, romODCACert := buildUPIDBindingTestChain(t)
+
+	romHash := sha256.Sum256(romODCACert.Raw)
+	hwSerial := make([]byte, upid.HWSerialNumSize)
+	copy(hwSerial[:20], romHash[:20])
+	upidInfo := &upid.UPID{HWSerialNum: hwSerial}
+
+	leafHash := sha256.Sum256(leafCert.Raw)
+	amtCertInfo := &amt.SecureHBasedResponse{
+		HashAlgorithm: hashAlgorithmSHA256,
+		AMTCertHash:   strings.ToUpper(hex.EncodeToString(leafHash[:])),
+	}
+
+	err := VerifyCertificates(rawCerts, &mode, amtCertInfo, upidInfo)
+	assert.NoError(t, err)
+}
+
+func TestVerifyCertificates_UPIDBinding_Mismatch(t *testing.T) {
+	mode := 0
+	rawCerts, leafCert, romODCACert := buildUPIDBindingTestChain(t)
+
+	romHash := sha256.Sum256(romODCACert.Raw)
+	hwSerial := make([]byte, upid.HWSerialNumSize)
+	copy(hwSerial[:20], romHash[:20])
+	hwSerial[0] ^= 0xFF
+	upidInfo := &upid.UPID{HWSerialNum: hwSerial}
+
+	leafHash := sha256.Sum256(leafCert.Raw)
+	amtCertInfo := &amt.SecureHBasedResponse{
+		HashAlgorithm: hashAlgorithmSHA256,
+		AMTCertHash:   strings.ToUpper(hex.EncodeToString(leafHash[:])),
+	}
+
+	err := VerifyCertificates(rawCerts, &mode, amtCertInfo, upidInfo)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "UPID CSME HW ID does not match ROM ODCA certificate hash")
 }

--- a/internal/commands/activate/local.go
+++ b/internal/commands/activate/local.go
@@ -27,6 +27,7 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/internal/interfaces"
 	localamt "github.com/device-management-toolkit/rpc-go/v2/internal/local/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
+	"github.com/device-management-toolkit/rpc-go/v2/pkg/upid"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
@@ -366,7 +367,7 @@ func (service *LocalActivationService) activateCCM() error {
 
 	if service.localTLSEnforced {
 		controlMode := service.config.ControlMode // Use stored control mode
-		tlsConfig = certs.GetTLSConfig(&controlMode, nil, service.context.SkipAMTCertCheck)
+		tlsConfig = certs.GetTLSConfig(&controlMode, nil, service.context.SkipAMTCertCheck, nil)
 	}
 	// Create WSMAN client
 	service.wsman = localamt.NewGoWSMANMessages(utils.LMSAddress)
@@ -513,7 +514,7 @@ func (service *LocalActivationService) commitCCMChanges() error {
 	// Re-setup WSMAN client with admin credentials before committing
 	// This is required because the initial setup used LSA credentials
 	controlMode := service.config.ControlMode
-	tlsConfig := certs.GetTLSConfig(&controlMode, nil, service.context.SkipAMTCertCheck)
+	tlsConfig := certs.GetTLSConfig(&controlMode, nil, service.context.SkipAMTCertCheck, nil)
 
 	err := service.wsman.SetupWsmanClient("admin", service.config.AMTPassword, service.localTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig)
 	if err != nil {
@@ -568,8 +569,19 @@ func (service *LocalActivationService) setupACMTLSConfig() (*tls.Config, error) 
 			return nil, err
 		}
 
+		var upidInfo *upid.UPID
+
+		if !service.context.SkipAMTCertCheck {
+			fetchedUPID, upidErr := service.amtCommand.GetUPID()
+			if upidErr != nil {
+				log.WithError(upidErr).Debug("Unable to read Intel UPID; skipping UPID binding verification")
+			} else {
+				upidInfo = fetchedUPID
+			}
+		}
+
 		controlMode := service.config.ControlMode // Use stored control mode
-		tlsConfig = certs.GetTLSConfig(&controlMode, &startHBasedResponse, service.context.SkipAMTCertCheck)
+		tlsConfig = certs.GetTLSConfig(&controlMode, &startHBasedResponse, service.context.SkipAMTCertCheck, upidInfo)
 		// Add client certificate to TLS config
 		tlsCert := tls.Certificate{
 			PrivateKey: certsAndKeys.keys[0],

--- a/internal/commands/activate/local_test.go
+++ b/internal/commands/activate/local_test.go
@@ -5,8 +5,13 @@
 package activate
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"errors"
+	"math/big"
 	"testing"
 	"time"
 
@@ -15,6 +20,7 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/pthi"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/upid"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
 )
 
 func TestLocalActivateCmd_Validate(t *testing.T) {
@@ -221,6 +227,9 @@ type MockAMTCommand struct {
 	hbcResponses    []amt.SecureHBasedResponse
 	hbcErrors       []error
 	hbcCalls        int
+	upidValue       *upid.UPID
+	upidErr         error
+	upidCalls       int
 }
 type MockChangeEnabled struct {
 	amtEnabled bool
@@ -357,7 +366,85 @@ func (m *MockAMTCommand) StartConfigurationHBased(params amt.SecureHBasedParamet
 }
 
 func (m *MockAMTCommand) GetUPID() (*upid.UPID, error) {
-	return nil, nil
+	m.upidCalls++
+
+	if m.upidErr != nil {
+		return nil, m.upidErr
+	}
+
+	return m.upidValue, nil
+}
+
+func generateTestPFXBase64(t *testing.T, password string) string {
+	t.Helper()
+
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("failed to generate serial number: %v", err)
+	}
+
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: "Test Root CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+
+	leafSerialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("failed to generate leaf serial number: %v", err)
+	}
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber:          leafSerialNumber,
+		Subject:               pkix.Name{CommonName: "Test Provisioning Leaf"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootCert, &leafKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("failed to parse leaf certificate: %v", err)
+	}
+
+	pfx, err := pkcs12.Legacy.Encode(leafKey, leafCert, []*x509.Certificate{rootCert}, password)
+	if err != nil {
+		t.Fatalf("failed to encode pfx: %v", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(pfx)
 }
 
 func (m *MockAMTCommand) GetFlog() ([]byte, error) {
@@ -1022,6 +1109,65 @@ func TestLocalActivationService_setupACMTLSConfig(t *testing.T) {
 			_, err := service.setupACMTLSConfig()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("setupACMTLSConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLocalActivationService_setupACMTLSConfig_SkipCertCheckSkipsUPIDFetch(t *testing.T) {
+	password := "cert-password"
+	validPFX := generateTestPFXBase64(t, password)
+
+	tests := []struct {
+		name              string
+		skipAMTCertCheck  bool
+		expectedUPIDCalls int
+	}{
+		{
+			name:              "fetches UPID when cert check enabled",
+			skipAMTCertCheck:  false,
+			expectedUPIDCalls: 1,
+		},
+		{
+			name:              "skips UPID fetch when cert check disabled",
+			skipAMTCertCheck:  true,
+			expectedUPIDCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAMT := &MockAMTCommand{
+				hbcResponses: []amt.SecureHBasedResponse{{
+					Status: "AMT_STATUS_SUCCESS",
+				}},
+				upidValue: &upid.UPID{},
+			}
+
+			service := &LocalActivationService{
+				amtCommand: mockAMT,
+				config: LocalActivationConfig{
+					ControlMode:         0,
+					ProvisioningCert:    validPFX,
+					ProvisioningCertPwd: password,
+				},
+				context: &commands.Context{
+					SkipAMTCertCheck: tt.skipAMTCertCheck,
+				},
+				localTLSEnforced: true,
+			}
+
+			tlsConfig, err := service.setupACMTLSConfig()
+			if err != nil {
+				t.Fatalf("setupACMTLSConfig() unexpected error: %v", err)
+			}
+
+			if tlsConfig == nil {
+				t.Fatal("setupACMTLSConfig() returned nil tls config")
+			}
+
+			if mockAMT.upidCalls != tt.expectedUPIDCalls {
+				t.Fatalf("GetUPID() calls = %d, expected %d", mockAMT.upidCalls, tt.expectedUPIDCalls)
 			}
 		})
 	}

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -1839,7 +1839,7 @@ func (s *InfoService) ensureWSMANClient(controlMode int) error {
 
 	var tlsConfig *tls.Config
 	if s.localTLSEnforced {
-		tlsConfig = certs.GetTLSConfig(&controlMode, nil, s.skipAMTCertCheck)
+		tlsConfig = certs.GetTLSConfig(&controlMode, nil, s.skipAMTCertCheck, nil)
 	} else {
 		tlsConfig = &tls.Config{InsecureSkipVerify: s.skipAMTCertCheck}
 	}

--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -95,7 +95,7 @@ func (cmd *AMTBaseCmd) EnsureWSMAN(ctx *Context) error {
 
 	cmd.WSMan = localamt.NewGoWSMANMessages(utils.LMSAddress)
 
-	tlsConfig := certs.GetTLSConfig(&cmd.ControlMode, nil, DefaultSkipAMTCertCheck)
+	tlsConfig := certs.GetTLSConfig(&cmd.ControlMode, nil, DefaultSkipAMTCertCheck, nil)
 	if err := cmd.WSMan.SetupWsmanClient("admin", ctx.AMTPassword, cmd.LocalTLSEnforced, log.GetLevel() == log.TraceLevel, tlsConfig); err != nil {
 		return fmt.Errorf("failed to setup WSMAN client: %w", err)
 	}
@@ -184,6 +184,7 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 
 	cmd.ControlMode = controlMode
 	cmd.HECIAvailable = true
+	log.Tracef("AMTBaseCmd detected control mode: %d", cmd.ControlMode)
 
 	// Determine if TLS is enforced on local ports; needed even if we skip full WSMAN setup
 	resp, _ := amtCommand.GetChangeEnabled()
@@ -191,7 +192,11 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 		cmd.LocalTLSEnforced = true
 
 		log.Info("TLS is enforced on local ports")
+	} else {
+		log.Trace("TLS is not enforced on local ports")
 	}
+
+	log.Tracef("AMTBaseCmd setup complete: controlMode=%d localTLSEnforced=%t", cmd.ControlMode, cmd.LocalTLSEnforced)
 
 	cmd.afterApplied = true
 

--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -31,7 +31,7 @@ func (cmd *DeactivateCmd) setupTLSConfig(ctx *Context) *tls.Config {
 
 	if cmd.LocalTLSEnforced {
 		controlMode := cmd.GetControlMode()
-		tlsConfig = certs.GetTLSConfig(&controlMode, nil, ctx.SkipAMTCertCheck)
+		tlsConfig = certs.GetTLSConfig(&controlMode, nil, ctx.SkipAMTCertCheck, nil)
 	}
 
 	return tlsConfig

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -725,11 +725,12 @@ func TestExecuteHttpConsoleDeactivate_CustomDevicesEndpoint(t *testing.T) {
 	assert.Equal(t, 1, called, "expected exactly one DELETE request")
 }
 
-func TestSetupTLSConfig(t *testing.T) {
-	t.Run("TLS config with LocalTLSEnforced false", func(t *testing.T) {
+func TestDeactivateCmd_setupTLSConfig_ControlModePaths(t *testing.T) {
+	t.Run("TLS config in ACM with verification enabled", func(t *testing.T) {
 		cmd := &DeactivateCmd{}
 		cmd.LocalTLSEnforced = true
-		ctx := &Context{ControlMode: ControlModeACM}
+		cmd.ControlMode = ControlModeACM
+		ctx := &Context{SkipAMTCertCheck: false}
 
 		tlsConfig := cmd.setupTLSConfig(ctx)
 
@@ -737,17 +738,18 @@ func TestSetupTLSConfig(t *testing.T) {
 		assert.False(t, tlsConfig.InsecureSkipVerify)
 	})
 
-	t.Run("TLS config with LocalTLSEnforced true", func(t *testing.T) {
+	t.Run("TLS config in pre-provisioning uses custom verifier", func(t *testing.T) {
 		cmd := &DeactivateCmd{}
 		cmd.LocalTLSEnforced = true
+		cmd.ControlMode = 0
 		ctx := &Context{
-			SkipCertCheck: true,
-			ControlMode:   ControlModeACM,
+			SkipAMTCertCheck: false,
 		}
 
 		tlsConfig := cmd.setupTLSConfig(ctx)
 
 		assert.NotNil(t, tlsConfig)
-		// The actual config setup depends on the config.GetTLSConfig implementation
+		assert.True(t, tlsConfig.InsecureSkipVerify)
+		assert.NotNil(t, tlsConfig.VerifyPeerCertificate)
 	})
 }

--- a/internal/commands/diagnostics/wsman.go
+++ b/internal/commands/diagnostics/wsman.go
@@ -490,7 +490,7 @@ func extractXMLOutput(data any) string {
 }
 
 func (cmd *WSManGetCmd) newWSMANMessages(ctx *commands.Context) (wsman.Messages, error) {
-	tlsConfig := certs.GetTLSConfig(&cmd.ControlMode, nil, ctx.SkipAMTCertCheck)
+	tlsConfig := certs.GetTLSConfig(&cmd.ControlMode, nil, ctx.SkipAMTCertCheck, nil)
 
 	clientParams := client.Parameters{
 		Target:         utils.LMSAddress,

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -165,6 +165,7 @@ func NewExecutor(config ExecutorConfig) (Executor, error) {
 		}
 
 		client.localManagement = lme
+
 		client.isLME = true
 		if err := client.localManagement.Initialize(); err != nil {
 			return Executor{}, fmt.Errorf("failed to initialize LME connection: %w", err)

--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -312,11 +312,13 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 
 			if heci.useGUIDClient {
 				heci.mu.Unlock()
+
 				return 0, ErrDeviceNotInitialized
 			}
 
 			if initErr := heci.initLocked(heci.useLME, heci.useWD); initErr != nil {
 				heci.mu.Unlock()
+
 				return 0, initErr
 			}
 
@@ -456,6 +458,7 @@ func (heci *Driver) ReceiveMessage(buffer []byte, done *uint32) (bytesRead int, 
 
 			if initErr := heci.initLocked(heci.useLME, heci.useWD); initErr != nil {
 				heci.mu.Unlock()
+
 				return 0, initErr
 			}
 


### PR DESCRIPTION
Addresses - https://github.com/device-management-toolkit/rpc-go/issues/1083

Feature details - https://github.com/device-management-toolkit/rpc-go/wiki/SPIKE-%231083-ODCA-Certificate-Validation-for-AMT

ODCA Implementation guide - https://software.intel.com/sites/manageability/AMT_Implementation_and_Reference_Guide/default.htm?turl=WordDocuments%2FODCA.htm

Verification passed on Lunar Lake AMT 20 on Ubuntu.

command used for testing : sudo ./rpc-odca-v2 activate --local --profile ccm.yaml --key "ivQK+YEX06DRmyVTa7w/Jo6kN49B9kwv" -v --auth-endpoint http://<host_IP>/api/v1/authorize --auth-username standalone --auth-password "G@ppm0ym" -n

Workarounds needed for engineering test setups:
- For testing on engineering setup add `ODCA 2 CSME E` to `allowedOUPrefixes `
- For localhost SAN mismatch during testing, enable InsecureSkipVerify only to bypass Go hostname/SAN validation, and keep certificate validation enforced via VerifyPeerCertificate.

Sample Implementation: internal/cert/lmsTls.go
```
// generates a TLS configuration based on the provided mode.
func GetTLSConfig(mode *int, amtCertInfo *amt.SecureHBasedResponse, skipAMTCertCheck bool, upidInfo *upid.UPID) *tls.Config {
	tlsConfig := &tls.Config{}

	log.Tracef("GetTLSConfig: controlMode=%d skipAMTCertCheck=%t amtCertInfo=%t upidInfo=%t", *mode, skipAMTCertCheck, amtCertInfo != nil, upidInfo != nil)

	if *mode == 0 { // pre-provisioning mode
		// Use custom ODCA verification for pre-provisioning TLS.
		// We must bypass the default verifier so AMT's activation certificate chain
		// can be validated against the embedded ODCA trust store (without relying on
		// host OS roots / strict EKU checks).
		tlsConfig.InsecureSkipVerify = true
		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
			log.Tracef("ODCA VerifyPeerCertificate invoked: rawCerts=%d verifiedChains=%d skipAMTCertCheck=%t", len(rawCerts), len(verifiedChains), skipAMTCertCheck)

			if skipAMTCertCheck {
				log.Trace("Skipping ODCA verification because skip-amt-cert-check is enabled")

				return nil
			}

			log.Trace("Running ODCA certificate verification for pre-provisioning TLS")

			return VerifyCertificates(rawCerts, mode, amtCertInfo, upidInfo)
		}
	} else {
		// For ACM/CCM mode with local testing, use custom ODCA verifier for localhost
		if *mode == 1 {
			tlsConfig.InsecureSkipVerify = true
			tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
				log.Tracef("ODCA VerifyPeerCertificate invoked for ACM/CCM mode: rawCerts=%d verifiedChains=%d skipAMTCertCheck=%t", len(rawCerts), len(verifiedChains), skipAMTCertCheck)

				if skipAMTCertCheck {
					log.Trace("Skipping ODCA verification for ACM/CCM because skip-amt-cert-check is enabled")

					return nil
				}

				log.Trace("Running ODCA certificate verification for ACM/CCM TLS (localhost)")

				return VerifyCertificates(rawCerts, mode, amtCertInfo, upidInfo)
			}
		} else {
			tlsConfig.InsecureSkipVerify = skipAMTCertCheck
			log.Tracef("ODCA VerifyPeerCertificate not installed because control mode is %d", *mode)
		}
		// default tls config if device is in ACM or CCM
		log.Trace("Setting default TLS Config for ACM/CCM mode")
	}

	return tlsConfig
}
```

**The implementation doesn't cover the CRL Check part as that will be handled in a separate issue**
