### PR TITLE
fix: skip AMT password prompt for local CCM deactivation

### DIFF
--- a/internal/commands/deactivate.go
+++ b/internal/commands/deactivate.go
@@ -48,10 +48,13 @@ type DeactivateCmd struct {
 	TLSTunnel          bool   `help:"Tunnel TLS to AMT through RPS (rpc-go forwards plain bytes on the TLS port)" name:"tls-tunnel"`
 }
 
-// RequiresAMTPassword indicates whether this command requires AMT password
-// For deactivate, password is required for both local and remote modes
+// RequiresAMTPassword indicates whether this command requires AMT password.
 func (cmd *DeactivateCmd) RequiresAMTPassword() bool {
-	// Password required for local mode or remote mode (when URL is provided)
+	// CCM deactivation uses HECI Unprovision directly — no password or WSMAN needed.
+	if cmd.Local && cmd.GetControlMode() == ControlModeCCM {
+		return false
+	}
+
 	return cmd.Local || cmd.URL != ""
 }
 

--- a/internal/commands/deactivate_test.go
+++ b/internal/commands/deactivate_test.go
@@ -234,6 +234,30 @@ func TestDeactivateCmd_Run_Local_CCM(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "partial unprovisioning is only supported in ACM mode")
 	})
+
+	t.Run("CCM deactivation does not prompt for AMT password", func(t *testing.T) {
+		// Failing reader: a prompt would error before reaching Unprovision.
+		originalPR := utils.PR
+		utils.PR = &MockPasswordReaderFail{}
+
+		defer func() { utils.PR = originalPR }()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockAMT := mock.NewMockInterface(ctrl)
+		mockAMT.EXPECT().GetUUID().Return("test-guid", nil)
+		mockAMT.EXPECT().Unprovision().Return(0, nil)
+
+		ctx := &Context{AMTCommand: mockAMT} // no AMTPassword
+		cmd := DeactivateCmd{Local: true}
+		cmd.ControlMode = ControlModeCCM
+
+		assert.False(t, cmd.RequiresAMTPassword())
+
+		err := cmd.Run(ctx)
+		assert.NoError(t, err)
+	})
 }
 
 func TestDeactivateCmd_Run_Local_GetControlModeFailure(t *testing.T) {


### PR DESCRIPTION
Local deactivation prompted for an AMT password and set up a WSMAN session regardless of control mode. In CCM the unprovision goes through the HECI Unprovision call directly, which needs neither a password nor WSMAN, so the prompt was unnecessary and the doomed WSMAN setup logged spurious "Failed to connect to LMS" and TLS certificate errors.