### PR TITLE
feat(rps): display structured per-component activation result

### DIFF
--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -40,6 +40,34 @@ type StatusMessage struct {
 	Network          string `json:"Network,omitempty"`
 	CIRAConnection   string `json:"CIRAConnection,omitempty"`
 	TLSConfiguration string `json:"TLSConfiguration,omitempty"`
+	// Components carries the additive, structured per-component provisioning result
+	// introduced by RPS (rps#2665). Older RPS releases omit it; in that case the flat
+	// fields above remain the source of truth.
+	Components *ComponentResults `json:"Components,omitempty"`
+}
+
+// Component result status values, mirroring the RPS ComponentResultStatus enum (rps#2665).
+const (
+	ComponentResultSuccess       = "Success"
+	ComponentResultFailure       = "Failure"
+	ComponentResultNotApplicable = "NotApplicable"
+)
+
+// ComponentResult is the per-component outcome of an activation step.
+type ComponentResult struct {
+	Result  string `json:"Result"`            // Success, Failure, or NotApplicable
+	Mode    string `json:"Mode,omitempty"`    // optional mode, e.g. ACM or LocalProfileSync
+	Details string `json:"Details,omitempty"` // optional human-readable note (failure reason on failure)
+}
+
+// ComponentResults groups the structured per-component activation results.
+type ComponentResults struct {
+	Activation      *ComponentResult `json:"Activation,omitempty"`
+	WiredNetwork    *ComponentResult `json:"WiredNetwork,omitempty"`
+	WirelessNetwork *ComponentResult `json:"WirelessNetwork,omitempty"`
+	TLS             *ComponentResult `json:"TLS,omitempty"`
+	CIRAProxy       *ComponentResult `json:"CIRAProxy,omitempty"`
+	CIRAConnection  *ComponentResult `json:"CIRAConnection,omitempty"`
 }
 
 // MessagePayload struct is used for the initial request to RPS to activate or manage a device

--- a/internal/rps/rps.go
+++ b/internal/rps/rps.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -235,10 +236,7 @@ func (amt *AMTActivationServer) ProcessMessage(message []byte) []byte {
 			log.Error(err)
 			log.Info(activation.Message)
 		} else {
-			log.Info("Status: " + statusMessage.Status)
-			log.Info("Network: " + statusMessage.Network)
-			log.Info("CIRA: " + statusMessage.CIRAConnection)
-			log.Info("TLS: " + statusMessage.TLSConfiguration)
+			logStatusMessage(statusMessage)
 		}
 
 		return nil
@@ -261,6 +259,90 @@ func (amt *AMTActivationServer) ProcessMessage(message []byte) []byte {
 	log.Trace("PAYLOAD:" + string(msgPayload))
 
 	return msgPayload
+}
+
+// logStatusMessage reports the activation result. When RPS provides the structured
+// per-component breakdown (rps#2665) it is rendered as an aligned summary with a status
+// glyph per component; otherwise the legacy flat status fields are logged for
+// compatibility with older RPS releases.
+func logStatusMessage(statusMessage StatusMessage) {
+	c := statusMessage.Components
+	if c == nil {
+		// Older RPS without the structured breakdown: log the legacy flat fields.
+		log.Info("Status: " + statusMessage.Status)
+		log.Info("Network: " + statusMessage.Network)
+		log.Info("CIRA: " + statusMessage.CIRAConnection)
+		log.Info("TLS: " + statusMessage.TLSConfiguration)
+
+		return
+	}
+
+	log.Info("Provisioning and Configuration Result : ")
+
+	// Every component surfaces its own mode inline (e.g. Activation shows [ACM]).
+	components := []struct {
+		label    string
+		result   *ComponentResult
+		showMode bool
+	}{
+		{"Activation", c.Activation, true},
+		{"Wired Network", c.WiredNetwork, true},
+		{"Wireless Network", c.WirelessNetwork, true},
+		{"TLS", c.TLS, true},
+		{"CIRA Proxy", c.CIRAProxy, true},
+		{"CIRA Connection", c.CIRAConnection, true},
+	}
+
+	// Align labels to the widest reportable component so the rows line up.
+	width := 0
+
+	for _, comp := range components {
+		if reportableComponent(comp.result) && len(comp.label) > width {
+			width = len(comp.label)
+		}
+	}
+
+	for _, comp := range components {
+		logComponentResult(comp.label, comp.result, comp.showMode, width)
+	}
+}
+
+// reportableComponent reports whether a component belongs in the summary. RPS sends a
+// NotApplicable entry for every component that was not part of the configuration (and omits
+// components it never reported); both are dropped so the summary shows only the steps that ran.
+func reportableComponent(result *ComponentResult) bool {
+	return result != nil && result.Result != ComponentResultNotApplicable
+}
+
+// logComponentResult logs a single aligned component row, skipping components that are not
+// reportable (unreported or NotApplicable). Failures are logged at error level so they stay visible.
+func logComponentResult(label string, result *ComponentResult, showMode bool, width int) {
+	if !reportableComponent(result) {
+		return
+	}
+
+	// Row: two-space indent, then the padded "label:" so detail columns line up.
+	line := fmt.Sprintf("  %-*s", width+1, label+":")
+
+	// Append the mode inline as [Mode] (e.g. [ACM]) when the component carries one.
+	detail := result.Details
+	if showMode && result.Mode != "" {
+		if detail != "" {
+			detail += " "
+		}
+
+		detail += "[" + result.Mode + "]"
+	}
+
+	if detail != "" {
+		line += " " + detail
+	}
+
+	if result.Result == ComponentResultFailure {
+		log.Error(line)
+	} else {
+		log.Info(line)
+	}
 }
 
 func (amt *AMTActivationServer) GenerateHeartbeatResponse(activation Message) ([]byte, error) {

--- a/internal/rps/rps_test.go
+++ b/internal/rps/rps_test.go
@@ -5,6 +5,7 @@
 package rps
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/internal/flags"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -225,6 +227,87 @@ func TestProcessMessageSuccess(t *testing.T) {
 	server.Connect(true)
 	decodedMessage := server.ProcessMessage([]byte(activation))
 	assert.Nil(t, decodedMessage)
+}
+
+func TestProcessMessageStructuredSuccess(t *testing.T) {
+	// RPS rps#2665 structured per-component result rides alongside the legacy flat fields.
+	activation := `{
+        "method": "success",
+        "message": "{\"Status\":\"Admin control mode.\",\"Components\":{\"Activation\":{\"Result\":\"Success\",\"Mode\":\"Admin control mode.\"},\"WirelessNetwork\":{\"Result\":\"Failure\",\"Details\":\"Failed to add 1\"}}}"
+    }`
+	server := NewAMTActivationServer(testFlags)
+	server.Connect(true)
+	decodedMessage := server.ProcessMessage([]byte(activation))
+	assert.Nil(t, decodedMessage)
+}
+
+// captureLogOutput runs fn with logrus output redirected to a buffer and returns it.
+func captureLogOutput(fn func()) string {
+	var buf bytes.Buffer
+
+	orig := log.StandardLogger().Out
+
+	log.SetOutput(&buf)
+
+	defer log.SetOutput(orig)
+
+	fn()
+
+	return buf.String()
+}
+
+func TestLogStatusMessageStructured(t *testing.T) {
+	// Structured Components present: Success at info level, Failure at error level.
+	statusMessage := StatusMessage{
+		Status: "Admin control mode.",
+		Components: &ComponentResults{
+			Activation:      &ComponentResult{Result: ComponentResultSuccess, Mode: "Admin control mode."},
+			WirelessNetwork: &ComponentResult{Result: ComponentResultFailure, Details: "Failed to add 1"},
+			CIRAProxy:       &ComponentResult{Result: ComponentResultNotApplicable, Details: "CIRA proxy not part of this configuration"},
+		},
+	}
+
+	out := captureLogOutput(func() { logStatusMessage(statusMessage) })
+	assert.Contains(t, out, "level=info")
+	assert.Contains(t, out, "Activation:")
+	assert.Contains(t, out, "level=error")
+	assert.Contains(t, out, "Wireless Network:")
+	assert.Contains(t, out, "Failed to add 1")
+	// NotApplicable components are dropped from the summary.
+	assert.NotContains(t, out, "CIRA Proxy")
+	assert.NotContains(t, out, "CIRA proxy not part of this configuration")
+}
+
+func TestLogStatusMessageStructuredSurfacesHeaderAndMode(t *testing.T) {
+	// The structured branch logs the static header, and each component line must
+	// surface Mode inline when present (Activation shows [ACM]).
+	statusMessage := StatusMessage{
+		Status: "already enabled in admin mode.",
+		Components: &ComponentResults{
+			Activation:      &ComponentResult{Result: ComponentResultSuccess, Mode: "ACM", Details: "Already enabled in admin mode"},
+			WirelessNetwork: &ComponentResult{Result: ComponentResultSuccess, Mode: "LocalProfileSync", Details: "Local Profile Sync Configured"},
+		},
+	}
+
+	out := captureLogOutput(func() { logStatusMessage(statusMessage) })
+	assert.Contains(t, out, "Provisioning and Configuration Result : ")
+	assert.Contains(t, out, "Activation:")
+	assert.Contains(t, out, "Already enabled in admin mode")
+	assert.Contains(t, out, "[ACM]")
+	assert.Contains(t, out, "Wireless Network:")
+	assert.Contains(t, out, "[LocalProfileSync]")
+}
+
+func TestLogStatusMessageLegacyFallback(t *testing.T) {
+	// No Components: falls back to legacy flat-field logging.
+	statusMessage := StatusMessage{
+		Status:           "Admin control mode.",
+		Network:          "configured",
+		CIRAConnection:   "configured",
+		TLSConfiguration: "configured",
+	}
+
+	assert.NotPanics(t, func() { logStatusMessage(statusMessage) })
 }
 
 func TestProcessMessageUnformattedSuccess(t *testing.T) {


### PR DESCRIPTION
Parse and surface the structured per-component provisioning result that RPS now sends (rps#2665). When the success message includes the additive Components object, log each component (Activation, Wired/ Wireless Network, TLS, CIRA Proxy/Connection) with its result and details, logging failures at error level. When Components is absent (older RPS), fall back to the existing flat status lines, so behavior against older servers is unchanged.

Refs device-management-toolkit/rps#2665

**Status**

```
C:\DMT\Madhavi\rpc-go>go run ./cmd/rpc/main.go activate -u ws://192.168.69.253:8080 -profile acm
time="2026-06-26T15:05:17-07:00" level=info msg="Starting provisioning"
time="2026-06-26T15:05:17-07:00" level=info msg="Device already activated"
time="2026-06-26T15:05:52-07:00" level=info msg="Clearing previous configuration"
time="2026-06-26T15:06:12-07:00" level=info msg="Configuring network settings"
time="2026-06-26T15:06:14-07:00" level=info msg="Wired network configuration completed"
time="2026-06-26T15:06:20-07:00" level=info msg="Wireless network configuration completed"
time="2026-06-26T15:06:20-07:00" level=info msg="Configuring AMT features"
time="2026-06-26T15:06:24-07:00" level=info msg="AMT features completed: KVM, SOL, IDER (User Consent: None)"
time="2026-06-26T15:06:24-07:00" level=info msg="Configuring TLS"
time="2026-06-26T15:06:48-07:00" level=info msg="TLS configuration completed"
time="2026-06-26T15:06:48-07:00" level=info msg="Configuring CIRA remote access"
time="2026-06-26T15:07:02-07:00" level=info msg="CIRA configuration completed"
time="2026-06-26T15:07:02-07:00" level=info msg="Status: already enabled in admin mode."
time="2026-06-26T15:07:02-07:00" level=info msg="Network: Wired Network Configured. Wireless Only Local Profile Sync Configured"
time="2026-06-26T15:07:02-07:00" level=info msg="CIRA: Configured"
time="2026-06-26T15:07:02-07:00" level=info msg="TLS: Configured"
```

The raw RPS success message:

```
  "Components": {
    "Activation":      { "Result": "Success", "Mode": "ACM", "Details": "Activated to admin control mode" },
    "WiredNetwork":    { "Result": "Success", "Details": "Wired Network Configured" },
    "WirelessNetwork": { "Result": "Success", "Mode": "LocalProfileSync", "Details": "Wireless Only Local Profile Sync Configured" },
    "TLS":             { "Result": "Success", "Details": "Configured" },
    "CIRAConnection":  { "Result": "Success", "Details": "Configured" },
    "CIRAProxy":       { "Result": "NotApplicable", "Details": "CIRA proxy not part of this configuration" }
  } 
```