### PR TITLE
ci: bump golang base image digest to 1.26.4-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # **********************************************************************
 
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d as builder
+FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f as builder
 
 RUN apk update && apk upgrade && apk add --no-cache git
 


### PR DESCRIPTION
The pinned golang:1.26-alpine digest resolved to 1.26.3, which still carries stdlib CVE-2026-27145, CVE-2026-42504 and CVE-2026-42507 (fixed in 1.26.4). These fail the Trivy container scan since it includes UNKNOWN severity with exit-code 1. Refresh the digest to the current 1.26-alpine (1.26.4) to clear all flagged stdlib vulnerabilities.