### PR TITLE
feat: SMBIOS UUID fallback for non-vPro device sync

### DIFF
--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -413,9 +413,13 @@ type syncUPIDInfo struct {
 // SyncDeviceInfo sends a PATCH to the provided endpoint URL with the device info payload
 // The urlArg is expected to be a full URL to the devices endpoint (e.g., https://mps.example.com/api/v1/devices)
 func (s *InfoService) SyncDeviceInfo(ctx *Context, result *InfoResult, urlArg string, auth *ServerAuthFlags) error {
-	// Without a UUID (neither HECI nor SMBIOS available), we cannot identify the device
-	if result == nil || result.UUID == "" {
+	// Without a usable UUID (neither HECI nor SMBIOS available), we cannot identify the device.
+	if result == nil || strings.TrimSpace(result.UUID) == "" {
 		return fmt.Errorf("cannot sync: device UUID unavailable (neither HECI nor SMBIOS accessible)")
+	}
+
+	if utils.IsKnownInvalidUUID(result.UUID) {
+		return fmt.Errorf("cannot sync: invalid device UUID sentinel value")
 	}
 
 	// Use the provided URL directly as the target endpoint

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -782,7 +782,7 @@ func (s *InfoService) GetAMTInfo(cmd *AmtInfoCmd) (*InfoResult, error) {
 		if result.UUID == "" {
 			uuid, err := getSMBIOSSystemUUID()
 			if err != nil {
-				log.Warn("SMBIOS UUID not available: ", err)
+				log.Warn("SMBIOS UUID not available:", err)
 			} else {
 				result.UUID = uuid
 			}

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -93,6 +93,9 @@ var (
 			Foreground(lipgloss.Color("39"))
 )
 
+// test seam for SMBIOS UUID fallback in GetAMTInfo.
+var getSMBIOSSystemUUID = utils.GetSMBIOSSystemUUID
+
 func renderInfoHeader(title string) string {
 	return "\n" + infoIndent + infoHeaderStyle.Render(title) + "\n" + infoIndent +
 		infoSepStyle.Render(strings.Repeat("─", len([]rune(title)))) + "\n"
@@ -262,10 +265,6 @@ func (cmd *AmtInfoCmd) Run(ctx *Context) error {
 	service.wsman = cmd.GetWSManClient()
 	service.heciAvailable = cmd.HECIAvailable
 
-	if cmd.Sync && !cmd.HECIAvailable {
-		return fmt.Errorf("--sync requires administrator privileges and MEI driver to gather device data")
-	}
-
 	// If syncing, ensure we collect full device info regardless of selective flags
 	effectiveCmd := cmd
 	if cmd.Sync {
@@ -414,6 +413,11 @@ type syncUPIDInfo struct {
 // SyncDeviceInfo sends a PATCH to the provided endpoint URL with the device info payload
 // The urlArg is expected to be a full URL to the devices endpoint (e.g., https://mps.example.com/api/v1/devices)
 func (s *InfoService) SyncDeviceInfo(ctx *Context, result *InfoResult, urlArg string, auth *ServerAuthFlags) error {
+	// Without a UUID (neither HECI nor SMBIOS available), we cannot identify the device
+	if result == nil || result.UUID == "" {
+		return fmt.Errorf("cannot sync: device UUID unavailable (neither HECI nor SMBIOS accessible)")
+	}
+
 	// Use the provided URL directly as the target endpoint
 	endpoint := urlArg
 
@@ -763,12 +767,22 @@ func (s *InfoService) GetAMTInfo(cmd *AmtInfoCmd) (*InfoResult, error) {
 		result.Features = strings.TrimSpace(utils.DecodeAMTFeatures(result.AMT, result.SKU))
 	}
 
-	// Get UUID (requires HECI)
+	// Get UUID (requires HECI; falls back to SMBIOS for non-vPro devices)
 	if showAll || cmd.UUID {
 		if s.heciAvailable {
 			uuid, err := s.amtCommand.GetUUID()
 			if err != nil {
 				log.Error("Failed to get UUID: ", err)
+			} else {
+				result.UUID = uuid
+			}
+		}
+
+		// SMBIOS fallback when HECI is unavailable or failed
+		if result.UUID == "" {
+			uuid, err := getSMBIOSSystemUUID()
+			if err != nil {
+				log.Warn("SMBIOS UUID not available: ", err)
 			} else {
 				result.UUID = uuid
 			}

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -362,6 +362,7 @@ func TestAmtInfoCmd_Run_WithSync_UserPass_TokenExchange_CustomEndpoint(t *testin
 	assert.NoError(t, err)
 	assert.Equal(t, "Bearer custom-token", strings.TrimSpace(gotAuth))
 }
+
 func TestNewInfoService(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -1498,6 +1498,22 @@ func TestInfoService_SyncDeviceInfo_NilResult_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot sync: device UUID unavailable")
 }
 
+func TestInfoService_SyncDeviceInfo_SentinelUUID_ReturnsError(t *testing.T) {
+	service := NewInfoService(nil)
+	ctx := &Context{}
+
+	for _, sentinel := range []string{
+		"00000000-0000-0000-0000-000000000000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+		"03000200-0400-0500-0006-000700080009",
+	} {
+		result := &InfoResult{UUID: sentinel}
+		err := service.SyncDeviceInfo(ctx, result, "https://example.com/api/v1/devices", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid device UUID sentinel value")
+	}
+}
+
 func TestInfoService_GetAMTInfo_Proxy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/amt"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -361,7 +362,6 @@ func TestAmtInfoCmd_Run_WithSync_UserPass_TokenExchange_CustomEndpoint(t *testin
 	assert.NoError(t, err)
 	assert.Equal(t, "Bearer custom-token", strings.TrimSpace(gotAuth))
 }
-
 func TestNewInfoService(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -523,6 +523,52 @@ func TestInfoService_GetAMTInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInfoService_GetAMTInfo_UUIDFallbackToSMBIOS(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	orig := getSMBIOSSystemUUID
+	defer func() { getSMBIOSSystemUUID = orig }()
+
+	getSMBIOSSystemUUID = func() (string, error) {
+		return "e9e3aaba-2cc1-6c7b-c176-1c697a0bedfa", nil
+	}
+
+	mockAMT := mock.NewMockInterface(ctrl)
+	service := NewInfoService(mockAMT)
+	service.heciAvailable = false
+
+	result, err := service.GetAMTInfo(&AmtInfoCmd{UUID: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "e9e3aaba-2cc1-6c7b-c176-1c697a0bedfa", result.UUID)
+
+	assert.NotNil(t, result.HECIAvailable)
+	assert.False(t, *result.HECIAvailable)
+}
+
+func TestInfoService_GetAMTInfo_UUIDFallbackSMBIOSUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	orig := getSMBIOSSystemUUID
+	defer func() { getSMBIOSSystemUUID = orig }()
+
+	getSMBIOSSystemUUID = func() (string, error) {
+		return "", errors.New("not available")
+	}
+
+	mockAMT := mock.NewMockInterface(ctrl)
+	service := NewInfoService(mockAMT)
+	service.heciAvailable = false
+
+	result, err := service.GetAMTInfo(&AmtInfoCmd{UUID: true})
+	assert.NoError(t, err)
+	assert.Empty(t, result.UUID)
+
+	assert.NotNil(t, result.HECIAvailable)
+	assert.False(t, *result.HECIAvailable)
 }
 
 func TestInfoService_OutputJSON(t *testing.T) {
@@ -1430,6 +1476,25 @@ func TestInfoService_GetAMTInfo_RAS_PreProvisioningMode(t *testing.T) {
 	assert.NotNil(t, result.RAS)
 	assert.Equal(t, "heci-mps.example.com", result.RAS.MPSHostname)
 	assert.Equal(t, 0, result.RAS.MPSPort)
+}
+
+func TestInfoService_SyncDeviceInfo_EmptyUUID_ReturnsError(t *testing.T) {
+	service := NewInfoService(nil)
+	ctx := &Context{}
+	result := &InfoResult{}
+
+	err := service.SyncDeviceInfo(ctx, result, "https://example.com/api/v1/devices", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot sync: device UUID unavailable")
+}
+
+func TestInfoService_SyncDeviceInfo_NilResult_ReturnsError(t *testing.T) {
+	service := NewInfoService(nil)
+	ctx := &Context{}
+
+	err := service.SyncDeviceInfo(ctx, nil, "https://example.com/api/v1/devices", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot sync: device UUID unavailable")
 }
 
 func TestInfoService_GetAMTInfo_Proxy(t *testing.T) {

--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -148,13 +148,22 @@ func (cmd *AMTBaseCmd) AfterApply(amtCommand amt.Interface) error {
 			break
 		}
 
+		// Permanent hardware-absence errors — no point retrying (e.g. non-vPro device)
+		if isPermanentHECIError(err) {
+			log.Debugf("HECI permanently unavailable: %v", err)
+
+			break
+		}
+
 		if attempt < maxAttempts {
 			log.Warnf("GetControlMode failed (attempt %d/%d): %v. Retrying in %s...", attempt, maxAttempts, err, backoff)
 			time.Sleep(backoff)
 
 			continue
 		}
+	}
 
+	if err != nil {
 		// For commands that tolerate missing HECI (e.g. amtinfo), degrade gracefully
 		if cmd.SkipWSMANSetup {
 			log.Warn("HECI not available, AMT data will be limited")
@@ -203,4 +212,14 @@ func (cmd *AMTBaseCmd) GetControlMode() int {
 // This can be overridden by embedding commands if they have conditional requirements.
 func (cmd *AMTBaseCmd) RequiresAMTPassword() bool {
 	return true
+}
+
+// isPermanentHECIError returns true for errors that indicate HECI is structurally
+// absent and retrying will not help (non-vPro hardware or MEI driver not installed).
+func isPermanentHECIError(err error) bool {
+	msg := err.Error()
+
+	return strings.Contains(msg, "inappropriate ioctl for device") || // non-vPro: /dev/mei0 is wrong device type
+		strings.Contains(msg, "no such file or directory") || // MEI driver not installed
+		msg == utils.HECIDriverNotDetected.Error() // already-classified sentinel
 }

--- a/internal/commands/base_test.go
+++ b/internal/commands/base_test.go
@@ -6,6 +6,7 @@
 package commands
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
@@ -178,4 +179,25 @@ func TestAMTBaseCmd_GetWSManClient(t *testing.T) {
 	cmd := &AMTBaseCmd{}
 	// Initially should be nil
 	assert.Nil(t, cmd.GetWSManClient())
+}
+
+func TestIsPermanentHECIError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"inappropriate ioctl (non-vPro hardware)", errors.New("inappropriate ioctl for device"), true},
+		{"no such file (MEI driver missing)", errors.New("open /dev/mei0: no such file or directory"), true},
+		{"HECIDriverNotDetected sentinel", utils.HECIDriverNotDetected, true},
+		{"transient no such device", errors.New("no such device"), false},
+		{"transient device not connected", errors.New("The device is not connected."), false},
+		{"generic error", errors.New("some other error"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isPermanentHECIError(tt.err))
+		})
+	}
 }

--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -88,24 +88,6 @@ func NewPayload() Payload {
 	}
 }
 
-// knownInvalidUUIDs contains UUIDs that should be rejected during activation.
-// These UUIDs indicate AMT firmware is in an invalid/corrupted state.
-var knownInvalidUUIDs = []string{
-	"00000000-0000-0000-0000-000000000000", // Nil UUID - indicates uninitialized/error state
-	"03000200-0400-0500-0006-000700080009", // AMT firmware in corrupted/invalid state
-}
-
-// isKnownInvalidUUID checks if the UUID is in the list of known invalid UUIDs
-func isKnownInvalidUUID(uuid string) bool {
-	for _, invalidUUID := range knownInvalidUUIDs {
-		if uuid == invalidUUID {
-			return true
-		}
-	}
-
-	return false
-}
-
 // createPayload gathers data from ME to assemble required information for sending to the server
 func (p Payload) createPayload(dnsSuffix, hostname string, amtTimeout time.Duration) (MessagePayload, error) {
 	payload := MessagePayload{}
@@ -144,7 +126,7 @@ func (p Payload) createPayload(dnsSuffix, hostname string, amtTimeout time.Durat
 	}
 
 	// Validate UUID is not a known invalid value
-	if isKnownInvalidUUID(payload.UUID) {
+	if utils.IsKnownInvalidUUID(payload.UUID) {
 		return payload, utils.InvalidUUID
 	}
 
@@ -221,7 +203,7 @@ func (p Payload) CreateMessageRequest(req Request) (Message, error) {
 	payload.HostnameInfo = req.HostnameInfo
 
 	if req.UUID != "" {
-		if isKnownInvalidUUID(req.UUID) {
+		if utils.IsKnownInvalidUUID(req.UUID) {
 			return message, utils.InvalidUUID
 		}
 

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -379,37 +379,6 @@ func TestCreateMessageRequestTLSTunnelFields(t *testing.T) {
 	assert.True(t, msgPayload.TLSTunnel)
 }
 
-func TestIsKnownInvalidUUID(t *testing.T) {
-	tests := []struct {
-		name      string
-		uuid      string
-		isInvalid bool
-	}{
-		{
-			name:      "valid UUID",
-			uuid:      "1c113fd2-3325-4594-a272-54b2038beb07",
-			isInvalid: false,
-		},
-		{
-			name:      "all zeros UUID - invalid",
-			uuid:      "00000000-0000-0000-0000-000000000000",
-			isInvalid: true,
-		},
-		{
-			name:      "known bad UUID pattern - invalid",
-			uuid:      "03000200-0400-0500-0006-000700080009",
-			isInvalid: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isKnownInvalidUUID(tt.uuid)
-			assert.Equal(t, tt.isInvalid, result, "UUID: %s isInvalid=%v", tt.uuid, tt.isInvalid)
-		})
-	}
-}
-
 type MockAMTInvalidUUID struct {
 	MockAMT
 }

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -146,6 +147,21 @@ func ValidateUUID(uuidStr string) error {
 	}
 
 	return nil
+}
+
+// knownInvalidUUIDs are UUIDs that indicate an uninitialized, corrupted, or
+// otherwise unusable device identity. They must be rejected wherever a device
+// UUID is consumed (RPS activation, SMBIOS fallback, device sync).
+var knownInvalidUUIDs = []string{
+	"00000000-0000-0000-0000-000000000000", // Nil UUID — uninitialized/error state
+	"ffffffff-ffff-ffff-ffff-ffffffffffff", // All-ones — uninitialized SMBIOS/firmware
+	"03000200-0400-0500-0006-000700080009", // Known AMT firmware corrupted/invalid state
+}
+
+// IsKnownInvalidUUID reports whether u matches a known invalid/sentinel UUID.
+// Matching is case-insensitive and ignores surrounding whitespace.
+func IsKnownInvalidUUID(u string) bool {
+	return slices.Contains(knownInvalidUUIDs, strings.ToLower(strings.TrimSpace(u)))
 }
 
 func Pause(howManySeconds int) {

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -484,3 +484,25 @@ func TestDecodeAMT(t *testing.T) {
 		}
 	}
 }
+
+func TestIsKnownInvalidUUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		uuid     string
+		expected bool
+	}{
+		{"nil UUID", "00000000-0000-0000-0000-000000000000", true},
+		{"all-ones UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff", true},
+		{"corrupted firmware UUID", "03000200-0400-0500-0006-000700080009", true},
+		{"uppercase nil UUID", "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF", true},
+		{"surrounding whitespace", "  00000000-0000-0000-0000-000000000000\n", true},
+		{"valid UUID", "1c113fd2-3325-4594-a272-54b2038beb07", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsKnownInvalidUUID(tt.uuid))
+		})
+	}
+}

--- a/pkg/utils/smbios.go
+++ b/pkg/utils/smbios.go
@@ -55,12 +55,20 @@ func GetSMBIOSSystemUUID() (string, error) {
 }
 
 func getWindowsUUID() (string, error) {
-	out, err := runSMBIOSUUIDCommand("powershell", "-NoProfile", "-NonInteractive", "-Command", "(Get-CimInstance Win32_ComputerSystemProduct).UUID")
-	if err != nil {
-		return "", fmt.Errorf("failed to query UUID on Windows: %w", err)
+	const psCmd = "(Get-CimInstance Win32_ComputerSystemProduct).UUID"
+
+	var lastErr error
+
+	for _, ps := range []string{"powershell", "powershell.exe", "pwsh", "pwsh.exe"} {
+		out, err := runSMBIOSUUIDCommand(ps, "-NoProfile", "-NonInteractive", "-Command", psCmd)
+		if err == nil {
+			return normalizeUUID(out)
+		}
+
+		lastErr = err
 	}
 
-	return normalizeUUID(out)
+	return "", fmt.Errorf("failed to query UUID on Windows: %w", lastErr)
 }
 
 func normalizeUUID(raw []byte) (string, error) {

--- a/pkg/utils/smbios.go
+++ b/pkg/utils/smbios.go
@@ -24,14 +24,16 @@ const (
 	goosWindows = "windows"
 )
 
-var readSMBIOSUUIDFile = os.ReadFile
-var currentGOOS = runtime.GOOS
-var runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+var (
+	readSMBIOSUUIDFile   = os.ReadFile
+	currentGOOS          = runtime.GOOS
+	runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-	return exec.CommandContext(ctx, name, args...).Output()
-}
+		return exec.CommandContext(ctx, name, args...).Output()
+	}
+)
 
 // GetSMBIOSSystemUUID reads the system UUID from OS-exposed SMBIOS sources.
 // Returns the UUID as a lowercase RFC 4122 string.
@@ -60,6 +62,7 @@ func getWindowsUUID() (string, error) {
 
 	return normalizeUUID(out)
 }
+
 func normalizeUUID(raw []byte) (string, error) {
 	parsed, err := uuid.Parse(strings.TrimSpace(string(raw)))
 	if err != nil {
@@ -67,15 +70,9 @@ func normalizeUUID(raw []byte) (string, error) {
 	}
 
 	normalized := strings.ToLower(parsed.String())
-	if isSentinelSMBIOSUUID(normalized) {
+	if IsKnownInvalidUUID(normalized) {
 		return "", fmt.Errorf("invalid SMBIOS UUID sentinel value")
 	}
 
 	return normalized, nil
-}
-
-func isSentinelSMBIOSUUID(u string) bool {
-	return u == "00000000-0000-0000-0000-000000000000" ||
-		u == "ffffffff-ffff-ffff-ffff-ffffffffffff" ||
-		u == "03000200-0400-0500-0006-000700080009"
 }

--- a/pkg/utils/smbios.go
+++ b/pkg/utils/smbios.go
@@ -27,7 +27,7 @@ const (
 var readSMBIOSUUIDFile = os.ReadFile
 var currentGOOS = runtime.GOOS
 var runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	return exec.CommandContext(ctx, name, args...).Output()

--- a/pkg/utils/smbios.go
+++ b/pkg/utils/smbios.go
@@ -1,0 +1,81 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const productUUIDPath = "/sys/class/dmi/id/product_uuid"
+
+const (
+	goosLinux   = "linux"
+	goosWindows = "windows"
+)
+
+var readSMBIOSUUIDFile = os.ReadFile
+var currentGOOS = runtime.GOOS
+var runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// GetSMBIOSSystemUUID reads the system UUID from OS-exposed SMBIOS sources.
+// Returns the UUID as a lowercase RFC 4122 string.
+func GetSMBIOSSystemUUID() (string, error) {
+	switch currentGOOS {
+	case goosLinux:
+		// Linux path: read UUID directly from DMI sysfs.
+		raw, err := readSMBIOSUUIDFile(productUUIDPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read SMBIOS product UUID: %w", err)
+		}
+
+		return normalizeUUID(raw)
+	case goosWindows:
+		return getWindowsUUID()
+	default:
+		return "", fmt.Errorf("SMBIOS UUID lookup not supported on %s", currentGOOS)
+	}
+}
+
+func getWindowsUUID() (string, error) {
+	out, err := runSMBIOSUUIDCommand("powershell", "-NoProfile", "-NonInteractive", "-Command", "(Get-CimInstance Win32_ComputerSystemProduct).UUID")
+	if err != nil {
+		return "", fmt.Errorf("failed to query UUID on Windows: %w", err)
+	}
+
+	return normalizeUUID(out)
+}
+func normalizeUUID(raw []byte) (string, error) {
+	parsed, err := uuid.Parse(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return "", fmt.Errorf("invalid SMBIOS UUID: %w", err)
+	}
+
+	normalized := strings.ToLower(parsed.String())
+	if isSentinelSMBIOSUUID(normalized) {
+		return "", fmt.Errorf("invalid SMBIOS UUID sentinel value")
+	}
+
+	return normalized, nil
+}
+
+func isSentinelSMBIOSUUID(u string) bool {
+	return u == "00000000-0000-0000-0000-000000000000" ||
+		u == "ffffffff-ffff-ffff-ffff-ffffffffffff" ||
+		u == "03000200-0400-0500-0006-000700080009"
+}

--- a/pkg/utils/smbios_test.go
+++ b/pkg/utils/smbios_test.go
@@ -84,7 +84,7 @@ func TestGetSMBIOSSystemUUID(t *testing.T) {
 		assert.Contains(t, err.Error(), "sentinel")
 	})
 
-	t.Run("windows fallback", func(t *testing.T) {
+	t.Run("windows powershell fallback", func(t *testing.T) {
 		currentGOOS = "windows"
 		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
 			return nil, errors.New("not available")
@@ -96,6 +96,30 @@ func TestGetSMBIOSSystemUUID(t *testing.T) {
 		u, err := GetSMBIOSSystemUUID()
 		require.NoError(t, err)
 		assert.Equal(t, "d83e613d-3b03-6bc0-36bd-48210b3594ec", u)
+	})
+
+	t.Run("windows pwsh fallback when powershell fails", func(t *testing.T) {
+		currentGOOS = "windows"
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return nil, errors.New("not available")
+		}
+
+		callCount := 0
+
+		runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
+			callCount++
+
+			if name == "powershell" || name == "powershell.exe" {
+				return nil, errors.New("not found")
+			}
+
+			return []byte("D83E613D-3B03-6BC0-36BD-48210B3594EC\n"), nil
+		}
+
+		u, err := GetSMBIOSSystemUUID()
+		require.NoError(t, err)
+		assert.Equal(t, "d83e613d-3b03-6bc0-36bd-48210b3594ec", u)
+		assert.GreaterOrEqual(t, callCount, 3, "should have tried powershell variants before pwsh")
 	})
 
 	t.Run("unsupported OS", func(t *testing.T) {

--- a/pkg/utils/smbios_test.go
+++ b/pkg/utils/smbios_test.go
@@ -109,10 +109,3 @@ func TestGetSMBIOSSystemUUID(t *testing.T) {
 		assert.Contains(t, err.Error(), "not supported")
 	})
 }
-
-func TestIsSentinelSMBIOSUUID(t *testing.T) {
-	assert.True(t, isSentinelSMBIOSUUID("00000000-0000-0000-0000-000000000000"))
-	assert.True(t, isSentinelSMBIOSUUID("ffffffff-ffff-ffff-ffff-ffffffffffff"))
-	assert.True(t, isSentinelSMBIOSUUID("03000200-0400-0500-0006-000700080009"))
-	assert.False(t, isSentinelSMBIOSUUID("d83e613d-3b03-6bc0-36bd-48210b3594ec"))
-}

--- a/pkg/utils/smbios_test.go
+++ b/pkg/utils/smbios_test.go
@@ -1,0 +1,118 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSMBIOSSystemUUID(t *testing.T) {
+	orig := readSMBIOSUUIDFile
+	origOS := currentGOOS
+	origCmd := runSMBIOSUUIDCommand
+
+	t.Cleanup(func() { readSMBIOSUUIDFile = orig })
+	t.Cleanup(func() { currentGOOS = origOS })
+	t.Cleanup(func() { runSMBIOSUUIDCommand = origCmd })
+
+	currentGOOS = "linux"
+
+	t.Run("valid UUID is normalized", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return []byte("D83E613D-3B03-6BC0-36BD-48210B3594EC\n"), nil
+		}
+
+		u, err := GetSMBIOSSystemUUID()
+		require.NoError(t, err)
+		assert.Equal(t, "d83e613d-3b03-6bc0-36bd-48210b3594ec", u)
+	})
+
+	t.Run("read failure", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return nil, errors.New("permission denied")
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read SMBIOS product UUID")
+	})
+
+	t.Run("invalid UUID format", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return []byte("not-a-uuid"), nil
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid SMBIOS UUID")
+	})
+
+	t.Run("all-zero UUID rejected", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return []byte("00000000-0000-0000-0000-000000000000"), nil
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sentinel")
+	})
+
+	t.Run("all-ff UUID rejected", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return []byte("ffffffff-ffff-ffff-ffff-ffffffffffff"), nil
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sentinel")
+	})
+
+	t.Run("known-corrupted UUID rejected", func(t *testing.T) {
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return []byte("03000200-0400-0500-0006-000700080009"), nil
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sentinel")
+	})
+
+	t.Run("windows fallback", func(t *testing.T) {
+		currentGOOS = "windows"
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return nil, errors.New("not available")
+		}
+		runSMBIOSUUIDCommand = func(name string, args ...string) ([]byte, error) {
+			return []byte("D83E613D-3B03-6BC0-36BD-48210B3594EC\n"), nil
+		}
+
+		u, err := GetSMBIOSSystemUUID()
+		require.NoError(t, err)
+		assert.Equal(t, "d83e613d-3b03-6bc0-36bd-48210b3594ec", u)
+	})
+
+	t.Run("unsupported OS", func(t *testing.T) {
+		currentGOOS = "unsupported-os"
+		readSMBIOSUUIDFile = func(_ string) ([]byte, error) {
+			return nil, errors.New("not available")
+		}
+
+		_, err := GetSMBIOSSystemUUID()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+}
+
+func TestIsSentinelSMBIOSUUID(t *testing.T) {
+	assert.True(t, isSentinelSMBIOSUUID("00000000-0000-0000-0000-000000000000"))
+	assert.True(t, isSentinelSMBIOSUUID("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+	assert.True(t, isSentinelSMBIOSUUID("03000200-0400-0500-0006-000700080009"))
+	assert.False(t, isSentinelSMBIOSUUID("d83e613d-3b03-6bc0-36bd-48210b3594ec"))
+}


### PR DESCRIPTION
When HECI is unavailable (non-vPro devices), read the System UUID from OS-exposed SMBIOS sources so the device can still be identified and synced. Normalize UUID output and reject sentinel values (all-zero/all-ff)
* Linux: /sys/class/dmi/id/product_uuid
* Windows: PowerShell Get-CimInstance Win32_ComputerSystemProduct

Also fixed skip HECI retries on permanent hardware-absence errors
On non-vPro devices, GetControlMode returns 'inappropriate ioctl for device' or 'no such file or directory' - both permanent errors that indicate HECI is structurally absent. Previously these triggered 3 retries with 4s backoff (12s total delay) before failing. Add isPermanentHECIError() to distinguish permanent from transient errors and break the retry loop immediately, so non-vPro devices degrade gracefully without the 12s wait.
* Before fix: 3 warnings + 12s delay for non-vPro
* After fix: single debug log + immediate fallback, no delay

Addresses #1355

Output

Before this PR, on Non-Vpro device, UUID was not fetched as HECI was unavailable.
On non-vPro devices, GetControlMode returns 'inappropriate ioctl for device' or 'no such file or directory' - both permanent errors that indicate HECI is structurally absent. Previously these triggered 3 retries with 4s backoff (12s total delay) before failing

```
sudo ./rpc amtinfo
[sudo] password for intel:
time="2026-06-16T09:04:28+05:30" level=warning msg="GetControlMode failed (attempt 1/4): inappropriate ioctl for device. Retrying in 4s..."
time="2026-06-16T09:04:32+05:30" level=warning msg="GetControlMode failed (attempt 2/4): inappropriate ioctl for device. Retrying in 4s..."
time="2026-06-16T09:04:36+05:30" level=warning msg="GetControlMode failed (attempt 3/4): inappropriate ioctl for device. Retrying in 4s..."
time="2026-06-16T09:04:40+05:30" level=warning msg="HECI not available, AMT data will be limited"
time="2026-06-16T09:04:40+05:30" level=info msg="Using configuration file: config.yaml (flag values may originate from this file)"

  MEI/HECI driver not detected — AMT may not be available on this device

  AMT Device Information
  ──────────────────────
  DNS Suffix
  DNS Suffix (OS)                node1
  Hostname (OS)                  node1
```

Now, using this PR, on Non-Vpro device
* read the System UUID from OS-exposed SMBIOS sources so the device can still be identified and synced.
* skip HECI retries on permanent hardware-absence errors: single debug log + immediate fallback, no delay.  Add isPermanentHECIError() to distinguish permanent from transient errors and break the retry loop immediately, so non-vPro devices degrade gracefully without the 12s wait.


Run amtinfo cmd

```
sudo ./rpc amtinfo
[sudo] password for intel:
time="2026-06-16T12:50:58+05:30" level=warning msg="HECI not available, AMT data will be limited"

  MEI/HECI driver not detected — AMT may not be available on this device

  AMT Device Information
  ──────────────────────
  UUID                           <non-vpro-edge-node-guid>
  DNS Suffix
  DNS Suffix (OS)                node1
  Hostname (OS)                  node1
```

Run the activate cmd - works only on AMT devices
On non-vpro device, we get the below:

```
sudo ./rpc activate --local --profile acmAMT16may20.yaml \
--key "bvCAbmWJJIC0DWZgwhH3ApwERdG+jtuZ" \
--skip-amt-cert-check -v \
--auth-endpoint "http://<host_ip_addr>:8181/api/v1/authorize" \
--auth-username <username> --auth-password "<password>"
time="2026-06-16T13:03:49+05:30" level=trace msg="Running AfterApply for AMTBaseCmd"
time="2026-06-16T13:03:49+05:30" level=debug msg="HECI permanently unavailable: inappropriate ioctl for device"
time="2026-06-16T13:03:49+05:30" level=error msg="Failed to execute due to access issues. Please ensure that Intel ME is present, the MEI driver is installed, and the runtime has administrator or root privileges."
time="2026-06-16T13:03:49+05:30" level=error msg="Error 2: HECIDriverNotDetected"
```

In current PR for non-vpro devices, sync will not yet work

```
sudo ./rpc amtinfo --sync --url http://<host-ip-addr>:8181/api/v1/devices \
  --auth-endpoint http://<host-ip-addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>"
time="2026-06-16T13:07:25+05:30" level=warning msg="HECI not available, AMT data will be limited"
time="2026-06-16T13:07:25+05:30" level=error msg="device not found; activate the device before syncing device info"
```

Sync  for non-vpro depends on PR https://github.com/device-management-toolkit/rpc-go/pull/1369
