### PR TITLE
build: bump golang:1.26-alpine digest to clear trivy CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # **********************************************************************
 
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 RUN apk update && apk upgrade && apk add --no-cache git
 


### PR DESCRIPTION
Re-pins the builder base image to the latest patched golang:1.26-alpine digest, resolving the base-layer vulnerabilities Trivy flags on PRs. Mirrors PR #1350.