### PR TITLE
fix(lme): make local TLS activation work reliably across AMT versions

### DIFF
--- a/internal/lm/apf_conn.go
+++ b/internal/lm/apf_conn.go
@@ -6,9 +6,11 @@
 package lm
 
 import (
+	"errors"
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,12 +20,14 @@ import (
 // lifecycle: the caller is responsible for Connect()/OPEN_CONFIRMATION and
 // for letting AMT's CHANNEL_CLOSE tear the channel down.
 type APFChannelConn struct {
-	lme      *LMEConnection
-	incoming chan []byte
+	lme       *LMEConnection
+	incoming  chan []byte
+	closeCh   chan struct{}
+	closed    atomic.Bool
+	closeOnce sync.Once
 
 	readMu       sync.Mutex
 	leftover     []byte
-	closed       bool
 	readDeadline time.Time
 }
 
@@ -36,51 +40,75 @@ func NewAPFChannelConn(lme *LMEConnection) *APFChannelConn {
 	stream := make(chan []byte, lmeAPFStreamBuffer)
 	lme.EnableTunnel(stream)
 
-	return &APFChannelConn{lme: lme, incoming: stream}
+	return &APFChannelConn{lme: lme, incoming: stream, closeCh: make(chan struct{})}
 }
 
 const lmeAPFStreamBuffer = 16
 
 func (c *APFChannelConn) Read(p []byte) (int, error) {
 	c.readMu.Lock()
-	defer c.readMu.Unlock()
+	if c.closeCh == nil {
+		c.closeCh = make(chan struct{})
+	}
 
 	if len(c.leftover) > 0 {
 		n := copy(p, c.leftover)
 		c.leftover = c.leftover[n:]
+		c.readMu.Unlock()
 
 		return n, nil
 	}
 
-	if c.closed {
+	if c.closed.Load() {
+		c.readMu.Unlock()
+
 		return 0, io.EOF
 	}
+
+	readDeadline := c.readDeadline
+	incoming := c.incoming
+	closeCh := c.closeCh
+	c.readMu.Unlock()
 
 	var (
 		chunk []byte
 		ok    bool
 	)
 
-	if c.readDeadline.IsZero() {
-		chunk, ok = <-c.incoming
+	if readDeadline.IsZero() {
+		select {
+		case chunk, ok = <-incoming:
+		case <-closeCh:
+			return 0, io.EOF
+		}
 	} else {
-		remaining := time.Until(c.readDeadline)
+		remaining := time.Until(readDeadline)
 		if remaining <= 0 {
 			return 0, apfDeadlineExceeded{}
 		}
 
 		t := time.NewTimer(remaining)
-		defer t.Stop()
-
 		select {
-		case chunk, ok = <-c.incoming:
+		case chunk, ok = <-incoming:
+			t.Stop()
+		case <-closeCh:
+			t.Stop()
+
+			return 0, io.EOF
 		case <-t.C:
 			return 0, apfDeadlineExceeded{}
 		}
 	}
 
 	if !ok {
-		c.closed = true
+		c.closed.Store(true)
+
+		return 0, io.EOF
+	}
+
+	c.readMu.Lock()
+	if c.closed.Load() {
+		c.readMu.Unlock()
 
 		return 0, io.EOF
 	}
@@ -89,11 +117,16 @@ func (c *APFChannelConn) Read(p []byte) (int, error) {
 	if n < len(chunk) {
 		c.leftover = chunk[n:]
 	}
+	c.readMu.Unlock()
 
 	return n, nil
 }
 
 func (c *APFChannelConn) Write(p []byte) (int, error) {
+	if c.lme == nil {
+		return 0, errors.New("nil LME connection")
+	}
+
 	if err := c.lme.Send(p); err != nil {
 		return 0, err
 	}
@@ -102,9 +135,19 @@ func (c *APFChannelConn) Write(p []byte) (int, error) {
 }
 
 func (c *APFChannelConn) Close() error {
+	c.closed.Store(true)
+
 	c.readMu.Lock()
-	c.closed = true
+	if c.closeCh == nil {
+		c.closeCh = make(chan struct{})
+	}
+
+	closeCh := c.closeCh
 	c.readMu.Unlock()
+
+	c.closeOnce.Do(func() {
+		close(closeCh)
+	})
 
 	return nil
 }

--- a/internal/lm/apf_conn.go
+++ b/internal/lm/apf_conn.go
@@ -1,0 +1,140 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lm
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// APFChannelConn adapts an LMEConnection's currently-open APF channel to
+// net.Conn so a tls.Client handshake (and subsequent encrypted writes/reads)
+// can be layered over the APF data stream. It does not own the channel
+// lifecycle: the caller is responsible for Connect()/OPEN_CONFIRMATION and
+// for letting AMT's CHANNEL_CLOSE tear the channel down.
+type APFChannelConn struct {
+	lme      *LMEConnection
+	incoming chan []byte
+
+	readMu       sync.Mutex
+	leftover     []byte
+	closed       bool
+	readDeadline time.Time
+}
+
+// NewAPFChannelConn enables streaming mode on the active LME session (so each
+// APF_CHANNEL_DATA chunk is delivered to a channel rather than buffered into
+// Tempdata until CHANNEL_CLOSE) and returns a net.Conn whose Read pops from
+// that channel and whose Write frames bytes as APF_CHANNEL_DATA on the open
+// channel via LMEConnection.Send.
+func NewAPFChannelConn(lme *LMEConnection) *APFChannelConn {
+	stream := make(chan []byte, lmeAPFStreamBuffer)
+	lme.EnableTunnel(stream)
+
+	return &APFChannelConn{lme: lme, incoming: stream}
+}
+
+const lmeAPFStreamBuffer = 16
+
+func (c *APFChannelConn) Read(p []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	if len(c.leftover) > 0 {
+		n := copy(p, c.leftover)
+		c.leftover = c.leftover[n:]
+
+		return n, nil
+	}
+
+	if c.closed {
+		return 0, io.EOF
+	}
+
+	var (
+		chunk []byte
+		ok    bool
+	)
+
+	if c.readDeadline.IsZero() {
+		chunk, ok = <-c.incoming
+	} else {
+		remaining := time.Until(c.readDeadline)
+		if remaining <= 0 {
+			return 0, apfDeadlineExceeded{}
+		}
+
+		t := time.NewTimer(remaining)
+		defer t.Stop()
+
+		select {
+		case chunk, ok = <-c.incoming:
+		case <-t.C:
+			return 0, apfDeadlineExceeded{}
+		}
+	}
+
+	if !ok {
+		c.closed = true
+
+		return 0, io.EOF
+	}
+
+	n := copy(p, chunk)
+	if n < len(chunk) {
+		c.leftover = chunk[n:]
+	}
+
+	return n, nil
+}
+
+func (c *APFChannelConn) Write(p []byte) (int, error) {
+	if err := c.lme.Send(p); err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+}
+
+func (c *APFChannelConn) Close() error {
+	c.readMu.Lock()
+	c.closed = true
+	c.readMu.Unlock()
+
+	return nil
+}
+
+func (c *APFChannelConn) LocalAddr() net.Addr  { return apfAddr{} }
+func (c *APFChannelConn) RemoteAddr() net.Addr { return apfAddr{} }
+
+func (c *APFChannelConn) SetDeadline(t time.Time) error {
+	return c.SetReadDeadline(t)
+}
+
+func (c *APFChannelConn) SetReadDeadline(t time.Time) error {
+	c.readMu.Lock()
+	c.readDeadline = t
+	c.readMu.Unlock()
+
+	return nil
+}
+
+// SetWriteDeadline is a no-op: APF writes go through HECI which enforces its
+// own timeouts; we don't layer another deadline on top.
+func (c *APFChannelConn) SetWriteDeadline(time.Time) error { return nil }
+
+type apfAddr struct{}
+
+func (apfAddr) Network() string { return "apf" }
+func (apfAddr) String() string  { return "amt-apf-channel" }
+
+type apfDeadlineExceeded struct{}
+
+func (apfDeadlineExceeded) Error() string   { return "apf channel read deadline exceeded" }
+func (apfDeadlineExceeded) Timeout() bool   { return true }
+func (apfDeadlineExceeded) Temporary() bool { return true }

--- a/internal/lm/apf_conn_test.go
+++ b/internal/lm/apf_conn_test.go
@@ -1,0 +1,103 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package lm
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestAPFChannelConnReadDeadlineExceeded(t *testing.T) {
+	conn := &APFChannelConn{
+		incoming: make(chan []byte),
+		closeCh:  make(chan struct{}),
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline() error = %v", err)
+	}
+
+	buf := make([]byte, 8)
+
+	n, err := conn.Read(buf)
+	if n != 0 {
+		t.Fatalf("Read() bytes = %d, want 0", n)
+	}
+
+	if err == nil {
+		t.Fatal("Read() error = nil, want timeout error")
+	}
+
+	var timeoutErr interface{ Timeout() bool }
+	if !errors.As(err, &timeoutErr) || !timeoutErr.Timeout() {
+		t.Fatalf("Read() error = %v, want timeout=true", err)
+	}
+}
+
+func TestAPFChannelConnReadLeftoverBuffering(t *testing.T) {
+	incoming := make(chan []byte, 1)
+	incoming <- []byte("abcdef")
+
+	conn := &APFChannelConn{
+		incoming: incoming,
+		closeCh:  make(chan struct{}),
+	}
+
+	buf := make([]byte, 4)
+
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("first Read() error = %v", err)
+	}
+
+	if got := string(buf[:n]); got != "abcd" {
+		t.Fatalf("first Read() = %q, want %q", got, "abcd")
+	}
+
+	n, err = conn.Read(buf)
+	if err != nil {
+		t.Fatalf("second Read() error = %v", err)
+	}
+
+	if got := string(buf[:n]); got != "ef" {
+		t.Fatalf("second Read() = %q, want %q", got, "ef")
+	}
+}
+
+func TestAPFChannelConnCloseUnblocksRead(t *testing.T) {
+	conn := &APFChannelConn{
+		incoming: make(chan []byte),
+		closeCh:  make(chan struct{}),
+	}
+
+	started := make(chan struct{})
+	result := make(chan error, 1)
+
+	go func() {
+		close(started)
+
+		_, err := conn.Read(make([]byte, 1))
+		result <- err
+	}()
+
+	<-started
+	time.Sleep(10 * time.Millisecond)
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Read() error after Close() = %v, want io.EOF", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Read() did not unblock after Close()")
+	}
+}

--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -8,8 +8,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"strings"
 	"sync"
+	"time"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/apf"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/heci"
@@ -17,6 +17,10 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
+
+// defaultLMEPort is the AMT-side management TCP port (HTTP) that a fresh
+// CHANNEL_OPEN targets before any RPS port_switch moves traffic to 16993.
+const defaultLMEPort uint32 = 16992
 
 // LMConnection is struct for managing connection to LMS
 type LMEConnection struct {
@@ -28,6 +32,19 @@ type LMEConnection struct {
 	// to 16992 (HTTP); switched to 16993 after RPS port_switch so subsequent
 	// wsman traffic rides the TLS-enforced port.
 	port uint32
+
+	// tunnel marks the connection as a persistent TLS tunnel. In tunnel mode a
+	// single Listen goroutine spans every TLS round of one session, so a benign
+	// HECI read timeout (no data this round) must NOT exit the loop the way the
+	// one-shot request/response path relies on - otherwise the rounds after the
+	// handshake response (the encrypted WSMAN request/response) have no reader.
+	tunnel bool
+	// stopListen retires the persistent tunnel Listen goroutine when a new TLS
+	// session (ClientHello) supersedes the current one, so two Receive loops
+	// never race on the same HECI handle. Recreated by EnableTunnel per session.
+	stopListen chan struct{}
+	stopClosed bool
+	stopMu     sync.Mutex
 }
 
 // SetPort changes the AMT-side port used for subsequent CHANNEL_OPENs.
@@ -35,16 +52,55 @@ func (lme *LMEConnection) SetPort(port uint32) {
 	lme.port = port
 }
 
-// apfInitHandler signals ready once ME has advertised tcpip-forward for all
-// four standard AMT ports. Returning after only 16992 races the trailing
-// 16993/623/664 registrations against the next CHANNEL_OPEN, which after a
-// mid-flow reinit can result in a lost OPEN_CONFIRMATION.
-var apfInitExpectedPorts = []uint32{16992, 16993, 623, 664}
+// EnableTunnel wires the APF session's StreamDataBuffer so each incoming
+// APF_CHANNEL_DATA chunk is delivered to stream immediately, instead of being
+// buffered into Tempdata and only flushed on CHANNEL_CLOSE. Required for
+// TLS-tunnel mode: the executor must forward AMT's TLS handshake bytes to
+// RPS as they arrive so RPS can produce the next handshake message, rather
+// than after AMT gives up and closes the channel.
+func (lme *LMEConnection) EnableTunnel(stream chan []byte) {
+	if lme.Session != nil {
+		lme.Session.StreamDataBuffer = stream
+	}
+
+	lme.stopMu.Lock()
+	lme.tunnel = true
+	lme.stopListen = make(chan struct{})
+	lme.stopClosed = false
+	lme.stopMu.Unlock()
+}
+
+// StopListen signals the current persistent tunnel Listen goroutine to exit at
+// its next loop iteration. Safe to call multiple times and before any tunnel
+// has been enabled. Used when a new TLS session supersedes the current one so
+// the old listener can't keep reading on a channel that's being torn down.
+func (lme *LMEConnection) StopListen() {
+	lme.stopMu.Lock()
+	defer lme.stopMu.Unlock()
+
+	if lme.stopListen != nil && !lme.stopClosed {
+		close(lme.stopListen)
+		lme.stopClosed = true
+	}
+}
+
+// AMT advertises tcpip-forward for a management port plus a matching
+// redirection port. Which ports appear depends on whether TLS is enforced:
+//   - non-TLS device: 16992 (management) + 623 (redirection)
+//   - TLS-enforced device: 16993 (management) + 664 (redirection)
+//
+// A TLS-enforced device never advertises 16992/623, so the handshake must not
+// wait for them - doing so blocks until the heci read timeout (~3s, per
+// utils.HeciReadTimeout) on every connection to an AMT with TLS enforced on
+// local ports.
+var (
+	apfMgmtPorts  = []uint32{16992, 16993}
+	apfRedirPorts = []uint32{623, 664}
+)
 
 type apfInitHandler struct {
 	apf.DefaultHandler
-	seenPorts        map[uint32]bool
-	portForwardReady bool
+	seenPorts map[uint32]bool
 }
 
 func (h *apfInitHandler) OnGlobalRequest(req apf.GlobalRequest) bool {
@@ -53,39 +109,30 @@ func (h *apfInitHandler) OnGlobalRequest(req apf.GlobalRequest) bool {
 	}
 
 	if h.seenPorts == nil {
-		h.seenPorts = make(map[uint32]bool, len(apfInitExpectedPorts))
+		h.seenPorts = make(map[uint32]bool, len(apfMgmtPorts)+len(apfRedirPorts))
 	}
 
 	h.seenPorts[req.Port] = true
 
-	// Port 16992 is mandatory; the others are advertised only when the
-	// matching service is enabled, so treat 16992 + any one of the rest
-	// (or just 16992 after the heci read timeout fallback) as ready.
-	if req.Port == 16992 {
-		h.portForwardReady = true
-	}
-
 	return false
 }
 
+// allExpectedSeen reports readiness once AMT has advertised a complete
+// management+redirection pair for the active mode. Requiring a full pair (not
+// just any management plus any redirection registration) preserves the original
+// guard against racing a trailing registration into the next CHANNEL_OPEN,
+// while avoiding mixed pairs when firmware advertises both modes.
 func (h *apfInitHandler) allExpectedSeen() bool {
-	if !h.portForwardReady {
-		return false
-	}
-
-	for _, p := range apfInitExpectedPorts {
-		if !h.seenPorts[p] {
-			return false
-		}
-	}
-
-	return true
+	// Non-TLS mode:      16992 (management) + 623 (redirection)
+	// TLS-enforced mode: 16993 (management) + 664 (redirection)
+	return (h.seenPorts[apfMgmtPorts[0]] && h.seenPorts[apfRedirPorts[0]]) ||
+		(h.seenPorts[apfMgmtPorts[1]] && h.seenPorts[apfRedirPorts[1]])
 }
 
 func NewLMEConnection(data chan []byte, errors chan error, wg *sync.WaitGroup) *LMEConnection {
 	lme := &LMEConnection{
 		ourChannel: 1,
-		port:       16992,
+		port:       defaultLMEPort,
 	}
 	lme.Command = pthi.NewCommand()
 	lme.Session = &apf.Session{
@@ -98,7 +145,42 @@ func NewLMEConnection(data chan []byte, errors chan error, wg *sync.WaitGroup) *
 	return lme
 }
 
-// Initialize runs the APF handshake until ME signals tcpip-forward on 16992 (or HECI times out).
+// WaitChan returns a channel that is closed once wg's counter reaches zero. It
+// lets a caller select on handshake completion alongside error/timeout channels
+// without open-coding the bridging goroutine at every channel-open site. The
+// spawned goroutine outlives the select when another branch fires first, which
+// is intentional: it unblocks as soon as the abandoned WaitGroup is drained.
+func WaitChan(wg *sync.WaitGroup) <-chan struct{} {
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	return done
+}
+
+// ResetHandshake installs a fresh WaitGroup on the LME session so each request
+// starts from a known-zero counter; a stale Done() from an abandoned Listen can
+// no longer race the current attempt's handshake wait. The new WaitGroup is
+// returned for callers that want to wait on it directly. When the session has
+// not been created yet the WaitGroup is returned without being wired in.
+func (lme *LMEConnection) ResetHandshake() *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
+
+	if lme.Session != nil {
+		lme.Session.WaitGroup = wg
+	}
+
+	return wg
+}
+
+// Initialize closes and reopens the MEI device, then runs the APF handshake.
+// Use this for a cold start where no MEI handle is open yet. When the HECI
+// layer has already transparently reopened the device (ErrDeviceReinitialized),
+// call runAPFHandshake instead to avoid a redundant close/open connect_client
+// round-trip.
 func (lme *LMEConnection) Initialize() error {
 	lme.Command.Close()
 
@@ -108,6 +190,15 @@ func (lme *LMEConnection) Initialize() error {
 		return err
 	}
 
+	return lme.runAPFHandshake()
+}
+
+// runAPFHandshake replays the APF protocol handshake (PROTOCOL_VERSION exchange
+// + tcpip-forward registrations) on an already-open MEI device. The firmware
+// drops the LME session on every CHANNEL_CLOSE, so this runs once per request;
+// keeping it independent of the device open lets the reinit path skip a second
+// MEI open that the HECI layer already performed.
+func (lme *LMEConnection) runAPFHandshake() error {
 	handler := &apfInitHandler{}
 	processor := apf.NewProcessor(handler)
 
@@ -125,7 +216,7 @@ func (lme *LMEConnection) Initialize() error {
 	for {
 		result, bytesRead, err := lme.Command.Receive()
 		if err != nil {
-			if errors.Is(err, heci.ErrReadTimeout) || strings.Contains(err.Error(), "heci read timeout") {
+			if heci.IsReadTimeout(err) {
 				// ME went idle; handshake phase is complete.
 				return nil
 			}
@@ -155,11 +246,27 @@ func (lme *LMEConnection) Initialize() error {
 	}
 }
 
+// ReestablishAPF replays the APF protocol handshake after the HECI layer has
+// transparently reopened the MEI device (ErrDeviceReinitialized). The firmware
+// drops its LME/APF session on the reopen, so a CHANNEL_OPEN issued before the
+// reinit is stale; callers must re-open the channel after this returns. The
+// device is already open at this point, so this only drives the handshake (no
+// redundant MEI close/open).
+func (lme *LMEConnection) ReestablishAPF() error {
+	return lme.runAPFHandshake()
+}
+
 // Connect initializes connection to LME via MEI Driver
 func (lme *LMEConnection) Connect() error {
 	log.Debug("Sending APF_CHANNEL_OPEN")
 
-	// Reset per-request session state before a new channel open.
+	// Reset per-request session state before a new channel open. Clearing
+	lme.Session.RecipientChannel = 0
+	// RecipientChannel is critical: a late APF_CHANNEL_CLOSE for the previous
+	// channel can arrive after EnableTunnel has swapped in the new stream but
+	// before OPEN_CONFIRMATION sets the new RecipientChannel; without this
+	// reset the recipient-match guard in ProcessChannelClose would treat the
+	// stale close as targeting the new stream and close it.
 	lme.Session.Tempdata = []byte{}
 	lme.Session.SenderChannel = 0
 	lme.Session.TXWindow = 0
@@ -177,7 +284,7 @@ func (lme *LMEConnection) Connect() error {
 
 		port := lme.port
 		if port == 0 {
-			port = 16992
+			port = defaultLMEPort
 		}
 
 		bin_buf := apf.ChannelOpenPort(lme.ourChannel, port)
@@ -189,11 +296,33 @@ func (lme *LMEConnection) Connect() error {
 				log.Warn(err.Error())
 				log.Warn("Retrying...")
 
-				if initErr := lme.Initialize(); initErr != nil {
-					return initErr
+				// On ErrDeviceReinitialized the HECI layer already reopened
+				// and reconnected the MEI device; only the APF session state
+				// was lost. Replay just the handshake instead of closing and
+				// reopening the device again - that second open costs an extra
+				// connect_client round-trip on every request. For the other
+				// error strings the device is not known-open, so fall back to
+				// a full Initialize (open + handshake).
+				var reinitErr error
+				if errors.Is(err, heci.ErrDeviceReinitialized) {
+					reinitErr = lme.runAPFHandshake()
+				} else {
+					reinitErr = lme.Initialize()
 				}
-				// Add delay after Initialize to give device time to stabilize.
-				utils.Pause(utils.HeciRetryDelay / 1000)
+
+				if reinitErr != nil {
+					return reinitErr
+				}
+
+				// On the ErrDeviceReinitialized path runAPFHandshake already
+				// blocked until the ME re-advertised all four tcpip-forward
+				// bindings (allExpectedSeen), so the device is ready - retry
+				// the CHANNEL_OPEN immediately. Only the full-Initialize
+				// fallback, which just reopened the device, gets a brief
+				// settle before retrying.
+				if !errors.Is(err, heci.ErrDeviceReinitialized) {
+					time.Sleep(utils.HeciReinitDelay * time.Millisecond)
+				}
 
 				continue
 			}
@@ -217,7 +346,7 @@ func logLMEError(err error) {
 		return
 	}
 
-	if errors.Is(err, heci.ErrReadTimeout) || strings.Contains(err.Error(), "heci read timeout") {
+	if heci.IsReadTimeout(err) {
 		log.Warn(err)
 
 		return
@@ -250,11 +379,41 @@ func (lme *LMEConnection) Send(data []byte) error {
 	return nil
 }
 
-// Listen dispatches APF messages for one transaction, then exits on CHANNEL_CLOSE or OPEN_FAILURE.
+// Listen dispatches APF messages. In one-shot (non-tunnel) mode it returns
+// after a single transaction (CHANNEL_CLOSE, OPEN_FAILURE, or a read timeout).
+// In tunnel mode it stays alive across every TLS round of the session: a benign
+// read timeout (no data this round) just loops, so the rounds after the
+// handshake response (the encrypted WSMAN request/response) still have a reader.
+// It exits on a real error, on CHANNEL_CLOSE for the confirmed channel, or when
+// StopListen is signaled for a superseding session.
 func (lme *LMEConnection) Listen() {
+	lme.stopMu.Lock()
+	tunnel := lme.tunnel
+	stop := lme.stopListen
+	lme.stopMu.Unlock()
+
 	for {
+		if tunnel && stop != nil {
+			select {
+			case <-stop:
+				log.Trace("LME tunnel listener stopped for superseding session")
+
+				return
+			default:
+			}
+		}
+
 		result, bytesRead, err := lme.Command.Receive()
 		if bytesRead == 0 || err != nil {
+			// In tunnel mode a benign read timeout means AMT simply had nothing
+			// to send this round (e.g. right after the client Finished, before
+			// the encrypted request arrives). Keep the single persistent
+			// listener alive across rounds instead of exiting; the one-shot
+			// path still exits so its caller's WaitGroup/error flow is intact.
+			if tunnel && (err == nil || heci.IsReadTimeout(err)) {
+				continue
+			}
+
 			log.Trace("NO MORE DATA TO READ")
 
 			// Non-blocking send so a closed error channel doesn't leak the goroutine.
@@ -286,11 +445,33 @@ func (lme *LMEConnection) Listen() {
 			return
 		}
 
-		// HandshakeConfirmed guards against stale CLOSE frames from a previous channel (reset by Connect)
-		if msgType == apf.APF_CHANNEL_CLOSE && lme.Session.HandshakeConfirmed {
+		// HandshakeConfirmed guards against stale CLOSE frames from a previous
+		// channel (reset by Connect). Additionally require the CLOSE to target
+		// our active channel: AMT replays stale CHANNEL_CLOSE frames for old
+		// channels (e.g. RecipientChannel 0 after an MEI reinit) while the
+		// current channel is still live and about to deliver its response.
+		// Exiting on those drops the real response and forces a needless
+		// re-handshake, so only a CLOSE for our channel ends the listener.
+		if msgType == apf.APF_CHANNEL_CLOSE && lme.Session.HandshakeConfirmed &&
+			closeTargetsOurChannel(msg, lme.Session) {
 			return
 		}
 	}
+}
+
+// closeTargetsOurChannel reports whether an APF_CHANNEL_CLOSE frame refers to
+// the session's currently confirmed channel. AMT addresses the close by our
+// (recipient) channel number, which Process records as Session.RecipientChannel
+// on OPEN_CONFIRMATION. A mismatch means the close is for a superseded channel
+// (commonly RecipientChannel 0 after an MEI reinit) and must not tear down the
+// active listener before AMT delivers the pending response.
+func closeTargetsOurChannel(msg []byte, session *apf.Session) bool {
+	const channelCloseHeaderLen = 5 // MessageType(1) + RecipientChannel(4)
+	if len(msg) < channelCloseHeaderLen {
+		return false
+	}
+
+	return binary.BigEndian.Uint32(msg[1:channelCloseHeaderLen]) == session.RecipientChannel
 }
 
 // Close closes the LME connection

--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -24,25 +24,68 @@ type LMEConnection struct {
 	Session    *apf.Session
 	ourChannel int
 	retries    int
+	// port is the AMT-side TCP port that each CHANNEL_OPEN targets. Defaults
+	// to 16992 (HTTP); switched to 16993 after RPS port_switch so subsequent
+	// wsman traffic rides the TLS-enforced port.
+	port uint32
 }
 
-// apfInitHandler signals ready once ME advertises tcpip-forward for port 16992.
+// SetPort changes the AMT-side port used for subsequent CHANNEL_OPENs.
+func (lme *LMEConnection) SetPort(port uint32) {
+	lme.port = port
+}
+
+// apfInitHandler signals ready once ME has advertised tcpip-forward for all
+// four standard AMT ports. Returning after only 16992 races the trailing
+// 16993/623/664 registrations against the next CHANNEL_OPEN, which after a
+// mid-flow reinit can result in a lost OPEN_CONFIRMATION.
+var apfInitExpectedPorts = []uint32{16992, 16993, 623, 664}
+
 type apfInitHandler struct {
 	apf.DefaultHandler
+	seenPorts        map[uint32]bool
 	portForwardReady bool
 }
 
 func (h *apfInitHandler) OnGlobalRequest(req apf.GlobalRequest) bool {
-	if req.RequestType == "tcpip-forward" && req.Port == 16992 {
+	if req.RequestType != "tcpip-forward" {
+		return false
+	}
+
+	if h.seenPorts == nil {
+		h.seenPorts = make(map[uint32]bool, len(apfInitExpectedPorts))
+	}
+
+	h.seenPorts[req.Port] = true
+
+	// Port 16992 is mandatory; the others are advertised only when the
+	// matching service is enabled, so treat 16992 + any one of the rest
+	// (or just 16992 after the heci read timeout fallback) as ready.
+	if req.Port == 16992 {
 		h.portForwardReady = true
 	}
 
 	return false
 }
 
+func (h *apfInitHandler) allExpectedSeen() bool {
+	if !h.portForwardReady {
+		return false
+	}
+
+	for _, p := range apfInitExpectedPorts {
+		if !h.seenPorts[p] {
+			return false
+		}
+	}
+
+	return true
+}
+
 func NewLMEConnection(data chan []byte, errors chan error, wg *sync.WaitGroup) *LMEConnection {
 	lme := &LMEConnection{
 		ourChannel: 1,
+		port:       16992,
 	}
 	lme.Command = pthi.NewCommand()
 	lme.Session = &apf.Session{
@@ -106,7 +149,7 @@ func (lme *LMEConnection) Initialize() error {
 			}
 		}
 
-		if handler.portForwardReady {
+		if handler.allExpectedSeen() {
 			return nil
 		}
 	}
@@ -132,12 +175,17 @@ func (lme *LMEConnection) Connect() error {
 			lme.ourChannel = channel
 		}
 
-		bin_buf := apf.ChannelOpen(lme.ourChannel)
+		port := lme.port
+		if port == 0 {
+			port = 16992
+		}
+
+		bin_buf := apf.ChannelOpenPort(lme.ourChannel, port)
 
 		err := lme.Command.Send(bin_buf.Bytes())
 		if err != nil {
 			lastErr = err
-			if attempts < 4 && (err.Error() == "no such device" || err.Error() == "The device is not connected.") {
+			if attempts < 4 && (errors.Is(err, heci.ErrDeviceReinitialized) || err.Error() == "no such device" || err.Error() == "The device is not connected.") {
 				log.Warn(err.Error())
 				log.Warn("Retrying...")
 

--- a/internal/lm/engine_test.go
+++ b/internal/lm/engine_test.go
@@ -99,6 +99,24 @@ func Test_NewLMEConnection(t *testing.T) {
 	assert.Equal(t, lmErrorChannel, lme.Session.ErrorBuffer)
 }
 
+func Test_apfInitHandler_allExpectedSeen_MatchingPairsOnly(t *testing.T) {
+	h := &apfInitHandler{seenPorts: map[uint32]bool{}}
+
+	assert.False(t, h.allExpectedSeen())
+
+	h.seenPorts[16992] = true
+	h.seenPorts[664] = true
+	assert.False(t, h.allExpectedSeen(), "mixed management/redirection pair must not be treated as ready")
+
+	h.seenPorts[623] = true
+	assert.True(t, h.allExpectedSeen(), "non-TLS pair should be ready")
+
+	h = &apfInitHandler{seenPorts: map[uint32]bool{}}
+	h.seenPorts[16993] = true
+	h.seenPorts[664] = true
+	assert.True(t, h.allExpectedSeen(), "TLS-enforced pair should be ready")
+}
+
 func TestLMEConnection_Initialize(t *testing.T) {
 	resetMock()
 
@@ -268,6 +286,7 @@ func newLMEWithQueuedHECI(handshakeConfirmed bool) (*LMEConnection, *queuedHECIM
 			Status:             make(chan bool, 1),
 			WaitGroup:          &sync.WaitGroup{},
 			HandshakeConfirmed: handshakeConfirmed,
+			RecipientChannel:   1,
 		},
 		ourChannel: 1,
 	}, mock
@@ -291,6 +310,51 @@ func Test_Listen_CloseExitsWhenHandshakeConfirmed(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Listen did not exit after CHANNEL_CLOSE with HandshakeConfirmed=true")
+	}
+
+	close(mock.queue)
+}
+
+// Test_Listen_StaleChannelCloseIgnoredWhenConfirmed verifies that a CHANNEL_CLOSE
+// for a channel other than our active one (e.g. a stale RecipientChannel 0 close
+// replayed by AMT after an MEI reinit) does NOT terminate Listen even when the
+// handshake is confirmed. Our channel is still live and about to deliver its
+// response; exiting here would drop it and force a needless re-handshake. An
+// OPEN_FAILURE is fed afterwards as an unambiguous exit signal to prove Listen
+// kept running past the stale close.
+func Test_Listen_StaleChannelCloseIgnoredWhenConfirmed(t *testing.T) {
+	lme, mock := newLMEWithQueuedHECI(true)
+
+	// ProcessChannelOpenFailure calls Done() on the WaitGroup, so pre-add to
+	// balance the counter (mirrors what Connect() does in production).
+	lme.Session.WaitGroup.Add(1)
+
+	done := make(chan struct{})
+
+	go func() {
+		lme.Listen()
+		close(done)
+	}()
+
+	// Stale CLOSE for channel 0 while our active channel is 1. Listen must NOT exit.
+	mock.queue <- apf.BuildChannelCloseBytes(0)
+
+	select {
+	case <-done:
+		t.Fatal("Listen exited on stale CHANNEL_CLOSE for a non-active channel")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// OPEN_FAILURE: 17 bytes big-endian — type(1) + recipient(4) + reason(4) + reserved(4) + reserved2(4).
+	openFailure := make([]byte, 17)
+
+	openFailure[0] = apf.APF_CHANNEL_OPEN_FAILURE
+	mock.queue <- openFailure
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not exit after OPEN_FAILURE following the ignored stale close")
 	}
 
 	close(mock.queue)

--- a/internal/local/amt/localTransport.go
+++ b/internal/local/amt/localTransport.go
@@ -29,13 +29,20 @@ import (
 // single source of truth for the value.
 var listenSafetyTimeout = utils.LMEChannelOpenTimeout * time.Second
 
+// localLMEListenStopTimeout bounds how long LocalTransport waits for a prior
+// persistent LME Listen goroutine to exit after StopListen is signaled.
+var localLMEListenStopTimeout = (utils.HeciReadTimeout + 1) * time.Second
+
 type LocalTransport struct {
 	local     lm.LocalMananger
-	lme       *lm.LMEConnection // non-nil when TLS termination is required
+	lme       *lm.LMEConnection // underlying LME session; TLS path uses it directly
 	data      chan []byte
 	errors    chan error
 	status    chan bool
 	tlsConfig *cryptotls.Config
+
+	lmeListenMu   sync.Mutex
+	lmeListenDone chan struct{}
 }
 
 // NewLocalTransport returns a LocalTransport that speaks cleartext HTTP over
@@ -88,6 +95,8 @@ func newLocalTransport(tlsConfig *cryptotls.Config, port uint32) *LocalTransport
 
 // Close closes the LME connection and releases the MEI device
 func (l *LocalTransport) Close() error {
+	l.stopLMEListen()
+
 	if l.local != nil {
 		return l.local.Close()
 	}
@@ -151,14 +160,6 @@ func (l *LocalTransport) attemptRoundTrip(r *http.Request, rawRequest []byte) (r
 	// Fresh handshake WaitGroup per attempt: if a prior Listen exited without
 	// signaling Done(), the old WG is abandoned rather than deadlocking this one.
 	handshake := l.resetHandshake()
-
-	// Drain the WG on the way out so the goroutine waiting on it never leaks,
-	// even when Listen exits before the APF handshake completes.
-	defer func() {
-		defer func() { _ = recover() }()
-
-		handshake.Done()
-	}()
 
 	if err := l.local.Connect(); err != nil {
 		logrus.Error(err)
@@ -259,22 +260,14 @@ func (l *LocalTransport) attemptTLSRoundTrip(r *http.Request, rawRequest []byte)
 
 	handshake := l.resetHandshake()
 
-	// Drain the WG on the way out so the goroutine created by lm.WaitChan(handshake)
-	// doesn't leak if Listen exits before the APF handshake completes.
-	defer func() {
-		defer func() { _ = recover() }()
-
-		handshake.Done()
-	}()
-
-	l.lme.StopListen()
+	l.stopLMEListen()
 	apfConn := lm.NewAPFChannelConn(l.lme)
 
 	if err := l.lme.Connect(); err != nil {
 		return nil, err
 	}
 
-	go l.lme.Listen()
+	l.startLMEListen()
 
 	handshakeDone := lm.WaitChan(handshake)
 
@@ -335,6 +328,46 @@ func (l *LocalTransport) attemptTLSRoundTrip(r *http.Request, rawRequest []byte)
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	return resp, nil
+}
+
+// stopLMEListen retires LocalTransport's prior persistent LME listener and
+// waits for exit so a new TLS round never races a second Receive loop on the
+// same HECI handle.
+func (l *LocalTransport) stopLMEListen() {
+	l.lmeListenMu.Lock()
+	done := l.lmeListenDone
+	l.lmeListenMu.Unlock()
+
+	if done == nil || l.lme == nil {
+		return
+	}
+
+	l.lme.StopListen()
+
+	select {
+	case <-done:
+	case <-time.After(localLMEListenStopTimeout):
+		logrus.Warn("LocalTransport TLS path: timed out waiting for previous LME listener to exit")
+	}
+
+	l.lmeListenMu.Lock()
+	if l.lmeListenDone == done {
+		l.lmeListenDone = nil
+	}
+	l.lmeListenMu.Unlock()
+}
+
+func (l *LocalTransport) startLMEListen() {
+	done := make(chan struct{})
+
+	l.lmeListenMu.Lock()
+	l.lmeListenDone = done
+	l.lmeListenMu.Unlock()
+
+	go func() {
+		l.lme.Listen()
+		close(done)
+	}()
 }
 
 // resetHandshake installs a fresh WaitGroup on the LME session so the current

--- a/internal/local/amt/localTransport.go
+++ b/internal/local/amt/localTransport.go
@@ -8,6 +8,8 @@ package amt
 import (
 	"bufio"
 	"bytes"
+	"context"
+	cryptotls "crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -23,41 +25,65 @@ import (
 )
 
 // listenSafetyTimeout guards against Listen exiting without signaling, leaving RoundTrip blocked.
-var listenSafetyTimeout = (utils.HeciReadTimeout + 15) * time.Second
+// Derived from utils.LMEChannelOpenTimeout so executor and localTransport share a
+// single source of truth for the value.
+var listenSafetyTimeout = utils.LMEChannelOpenTimeout * time.Second
 
 type LocalTransport struct {
-	local  lm.LocalMananger
-	data   chan []byte
-	errors chan error
-	status chan bool
+	local     lm.LocalMananger
+	lme       *lm.LMEConnection // non-nil when TLS termination is required
+	data      chan []byte
+	errors    chan error
+	status    chan bool
+	tlsConfig *cryptotls.Config
 }
 
+// NewLocalTransport returns a LocalTransport that speaks cleartext HTTP over
+// an APF channel on the AMT HTTP port (16992).
 func NewLocalTransport() *LocalTransport {
+	return newLocalTransport(nil, amtHTTPPort)
+}
+
+// NewLocalTransportTLS returns a LocalTransport that opens an APF channel to
+// the AMT TLS port (16993) and terminates AMT's TLS inside this process using
+// the supplied tls.Config, so HTTP/WSMAN traffic can be sent over the encrypted
+// stream. Used as the fallback when no LMS daemon is listening on the device.
+func NewLocalTransportTLS(tlsConfig *cryptotls.Config) *LocalTransport {
+	return newLocalTransport(tlsConfig, amtHTTPSPort)
+}
+
+const (
+	amtHTTPPort  uint32 = 16992
+	amtHTTPSPort uint32 = 16993
+)
+
+func newLocalTransport(tlsConfig *cryptotls.Config, port uint32) *LocalTransport {
 	lmDataChannel := make(chan []byte, 1)
 	lmErrorChannel := make(chan error, 1)
 	// A throwaway WG keeps the NewLMEConnection signature happy; each RoundTrip
 	// attempt installs a fresh WG via resetHandshake so a stuck counter from a
 	// prior failed attempt can't deadlock the next one.
-	lm := &LocalTransport{
-		local:  lm.NewLMEConnection(lmDataChannel, lmErrorChannel, &sync.WaitGroup{}),
-		data:   lmDataChannel,
-		errors: lmErrorChannel,
-	}
-	// defer lm.local.Close()
-	// defer close(lmDataChannel)
-	// defer close(lmErrorChannel)
-	// defer close(lmStatus)
+	conn := lm.NewLMEConnection(lmDataChannel, lmErrorChannel, &sync.WaitGroup{})
+	conn.SetPort(port)
 
-	err := lm.local.Initialize()
+	t := &LocalTransport{
+		local:     conn,
+		lme:       conn,
+		data:      lmDataChannel,
+		errors:    lmErrorChannel,
+		tlsConfig: tlsConfig,
+	}
+
+	err := t.local.Initialize()
 	if err != nil {
-		if errors.Is(err, heci.ErrReadTimeout) || strings.Contains(err.Error(), "heci read timeout") {
+		if heci.IsReadTimeout(err) {
 			logrus.Warn(err)
 		} else {
 			logrus.Error(err)
 		}
 	}
 
-	return lm
+	return t
 }
 
 // Close closes the LME connection and releases the MEI device
@@ -84,7 +110,17 @@ func (l *LocalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		resp, err := l.attemptRoundTrip(r, rawRequest)
+		var (
+			resp *http.Response
+			err  error
+		)
+
+		if l.tlsConfig != nil {
+			resp, err = l.attemptTLSRoundTrip(r, rawRequest)
+		} else {
+			resp, err = l.attemptRoundTrip(r, rawRequest)
+		}
+
 		if err == nil {
 			return resp, nil
 		}
@@ -134,12 +170,7 @@ func (l *LocalTransport) attemptRoundTrip(r *http.Request, rawRequest []byte) (r
 
 	// Wait for channel open confirmation (or open failure, which also calls Done()).
 	// Bounded so a Listen goroutine that exits early on a HECI error can't block forever.
-	handshakeDone := make(chan struct{})
-
-	go func() {
-		handshake.Wait()
-		close(handshakeDone)
-	}()
+	handshakeDone := lm.WaitChan(handshake)
 
 	select {
 	case <-handshakeDone:
@@ -216,18 +247,106 @@ Loop:
 	return response, nil
 }
 
+// attemptTLSRoundTrip opens an APF channel to AMT's TLS port, runs a TLS
+// handshake over it using NewAPFChannelConn as the underlying net.Conn, then
+// writes the pre-serialized HTTP request and reads the HTTP response back
+// through the TLS connection. Used when the device has no LMS daemon listening
+// on :16993 but TLS is enforced on the local AMT ports.
+func (l *LocalTransport) attemptTLSRoundTrip(r *http.Request, rawRequest []byte) (*http.Response, error) {
+	if l.lme == nil {
+		return nil, errors.New("TLS LocalTransport requires an LMEConnection")
+	}
+
+	handshake := l.resetHandshake()
+
+	// Drain the WG on the way out so the goroutine created by lm.WaitChan(handshake)
+	// doesn't leak if Listen exits before the APF handshake completes.
+	defer func() {
+		defer func() { _ = recover() }()
+
+		handshake.Done()
+	}()
+
+	l.lme.StopListen()
+	apfConn := lm.NewAPFChannelConn(l.lme)
+
+	if err := l.lme.Connect(); err != nil {
+		return nil, err
+	}
+
+	go l.lme.Listen()
+
+	handshakeDone := lm.WaitChan(handshake)
+
+	select {
+	case <-handshakeDone:
+		logrus.Trace("APF channel open confirmation received (TLS path)")
+	case errFromLMS := <-l.errors:
+		if errFromLMS != nil {
+			return nil, errFromLMS
+		}
+	case <-time.After(listenSafetyTimeout):
+		return nil, fmt.Errorf("timed out waiting for APF channel open after %s", listenSafetyTimeout)
+	}
+
+	tlsConn := cryptotls.Client(apfConn, l.tlsConfig)
+	if err := tlsConn.SetDeadline(time.Now().Add(listenSafetyTimeout)); err != nil {
+		_ = tlsConn.Close()
+
+		return nil, err
+	}
+
+	handshakeCtx, cancel := context.WithTimeout(context.Background(), listenSafetyTimeout)
+	defer cancel()
+
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		_ = tlsConn.Close()
+
+		return nil, fmt.Errorf("AMT TLS handshake over APF channel failed: %w", err)
+	}
+
+	state := tlsConn.ConnectionState()
+	logrus.Debugf("AMT TLS handshake over APF complete (version=0x%x, cipher=0x%x)", state.Version, state.CipherSuite)
+
+	if _, err := tlsConn.Write(rawRequest); err != nil {
+		_ = tlsConn.Close()
+
+		return nil, fmt.Errorf("write request over AMT TLS: %w", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), r)
+	if err != nil {
+		_ = tlsConn.Close()
+
+		return nil, fmt.Errorf("read response over AMT TLS: %w", err)
+	}
+
+	// Drain and re-buffer the body so we can close the TLS connection and the
+	// underlying APF channel before returning to the caller.
+	body, readErr := io.ReadAll(resp.Body)
+
+	_ = resp.Body.Close()
+	_ = tlsConn.Close()
+
+	if readErr != nil {
+		return nil, fmt.Errorf("read response body over AMT TLS: %w", readErr)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return resp, nil
+}
+
 // resetHandshake installs a fresh WaitGroup on the LME session so the current
 // round-trip attempt starts from a known-zero counter. On non-LME transports
 // the WaitGroup is returned but not wired through; the attempt's timeout guards
 // it regardless.
 func (l *LocalTransport) resetHandshake() *sync.WaitGroup {
-	wg := &sync.WaitGroup{}
-
-	if lmec, ok := l.local.(*lm.LMEConnection); ok && lmec.Session != nil {
-		lmec.Session.WaitGroup = wg
+	if lmec, ok := l.local.(*lm.LMEConnection); ok {
+		return lmec.ResetHandshake()
 	}
 
-	return wg
+	return &sync.WaitGroup{}
 }
 
 // isTransientLMEError reports whether err is a retryable APF/HTTP hiccup (EOF, channel refusal).

--- a/internal/local/amt/localTransport.go
+++ b/internal/local/amt/localTransport.go
@@ -38,7 +38,6 @@ type LocalTransport struct {
 	lme       *lm.LMEConnection // underlying LME session; TLS path uses it directly
 	data      chan []byte
 	errors    chan error
-	status    chan bool
 	tlsConfig *cryptotls.Config
 
 	lmeListenMu   sync.Mutex

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -59,6 +59,12 @@ func NewGoWSMANMessages(lmsAddress string) *GoWSMANMessages {
 }
 
 func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, logAMTMessages bool, tlsConfig *cryptotls.Config) error {
+	if useTLS && tlsConfig == nil {
+		logrus.Warn("SetupWsmanClient called with useTLS=true and nil tlsConfig; using default tls.Config")
+
+		tlsConfig = &cryptotls.Config{}
+	}
+
 	// Release any prior local transport's MEI handle; re-setup leaks handles otherwise.
 	if g.localTransport != nil {
 		if err := g.localTransport.Close(); err != nil {
@@ -102,8 +108,10 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 
 			if tlsConn, ok := conn.(*cryptotls.Conn); ok {
 				state := tlsConn.ConnectionState()
-				cert := state.PeerCertificates[0]
-				logrus.Trace("Server certificate: ", cert)
+				if len(state.PeerCertificates) > 0 {
+					cert := state.PeerCertificates[0]
+					logrus.Trace("Server certificate: ", cert)
+				}
 			}
 
 			defer conn.Close()

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -92,8 +92,11 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 
 		conn, err := dialer.DialContext(ctx, "tcp", utils.LMSAddress+":"+utils.LMSTLSPort)
 		if err != nil {
-			logrus.Info("Failed to connect to LMS.  We're probably going to fail now. Sorry!")
-			logrus.Error(err)
+			logrus.Debug("LMS TLS port not active, using LME-over-HECI with local TLS termination.")
+			logrus.Tracef("LMS TLS dial error: %v", err)
+
+			g.localTransport = NewLocalTransportTLS(tlsConfig)
+			clientParams.Transport = g.localTransport
 		} else {
 			logrus.Debug("Successfully connected to LMS.")
 

--- a/internal/local/amt/wsman.go
+++ b/internal/local/amt/wsman.go
@@ -98,8 +98,7 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 
 		conn, err := dialer.DialContext(ctx, "tcp", utils.LMSAddress+":"+utils.LMSTLSPort)
 		if err != nil {
-			logrus.Debug("LMS TLS port not active, using LME-over-HECI with local TLS termination.")
-			logrus.Tracef("LMS TLS dial error: %v", err)
+			logrus.Debugf("LMS TLS port not active, using LME-over-HECI with local TLS termination. LMS TLS dial error: %v", err)
 
 			g.localTransport = NewLocalTransportTLS(tlsConfig)
 			clientParams.Transport = g.localTransport
@@ -111,6 +110,8 @@ func (g *GoWSMANMessages) SetupWsmanClient(username, password string, useTLS, lo
 				if len(state.PeerCertificates) > 0 {
 					cert := state.PeerCertificates[0]
 					logrus.Trace("Server certificate: ", cert)
+				} else {
+					logrus.Warn("No peer certificates received from LMS TLS connection")
 				}
 			}
 

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -418,12 +418,16 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				log.Debug("Response sent to RPS, waiting for next RPS message")
 
 				if channelClosed {
-					log.Debug("LME tunnel: APF channel closed by AMT mid-session; asking RPS to re-handshake")
-
 					e.lmConnected = false
 
-					resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
-					e.server.Send(resetMsg)
+					if len(coalesced) == 0 {
+						log.Debug("LME tunnel: APF channel closed with no payload; asking RPS to re-handshake")
+
+						resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
+						e.server.Send(resetMsg)
+					} else {
+						log.Debug("LME tunnel: APF channel closed after payload; reopening channel on next TLS round")
+					}
 
 					return false
 				}

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -264,7 +264,11 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				e.waitGroup.Wait()
 			}
 
-			if !e.tlsTunnelActive {
+			// LME holds a persistent HECI handle whose tcpip-forward registrations
+			// are established once in Initialize(); closing it between requests
+			// invalidates the device for the next RPS message. MakeItSo's deferred
+			// Close() handles end-of-flow teardown for LME.
+			if !e.tlsTunnelActive && !e.isLME {
 				e.localManagement.Close()
 				e.lmConnected = false
 			}

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -5,7 +5,6 @@
 package rps
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/apf"
 	"github.com/device-management-toolkit/rpc-go/v2/internal/lm"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/heci"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
@@ -25,7 +25,9 @@ import (
 
 // handshakeTimeout bounds the wait for APF_CHANNEL_OPEN_CONFIRMATION so a Listen
 // goroutine that exits before signaling Done() can't deadlock the activation loop.
-var handshakeTimeout = (utils.HeciReadTimeout + 15) * time.Second
+// Derived from utils.LMEChannelOpenTimeout so executor and localTransport share a
+// single source of truth for the value.
+var handshakeTimeout = utils.LMEChannelOpenTimeout * time.Second
 
 // maxPortSwitchDelaySeconds caps the AMT TLS-restart wait that RPS asks for via
 // the port_switch payload. The server-supplied value is clamped to this maximum
@@ -39,14 +41,6 @@ var maxPortSwitchDelaySeconds = envInt("RPC_PORT_SWITCH_MAX_DELAY", 60)
 // if you see "Failed to establish TLS tunnel connection" errors immediately
 // after port_switch. Overridable via RPC_PORT_SWITCH_EXTRA_DELAY.
 var extraPortSwitchDelaySeconds = envInt("RPC_PORT_SWITCH_EXTRA_DELAY", 0)
-
-// lmePostKeygenPause: AMT 18.x briefly drops the LME MEI client after
-// GenerateKeyPair persists the new key; pausing here pre-empts an ENODEV on
-// the next CHANNEL_OPEN that would otherwise cost ~6s re-handshake.
-// Overridable (milliseconds) via RPC_LME_POST_KEYGEN_PAUSE_MS.
-var lmePostKeygenPause = time.Duration(envInt("RPC_LME_POST_KEYGEN_PAUSE_MS", 750)) * time.Millisecond
-
-const soapActionGenerateKeyPair = "AMT_PublicKeyManagementService/GenerateKeyPair"
 
 // envInt returns the integer value of env var name, or def if unset/invalid.
 func envInt(name string, def int) int {
@@ -70,6 +64,7 @@ func envInt(name string, def int) int {
 // being held by a server-requested delay.
 func waitWithSignal(d time.Duration) error {
 	sigCh := make(chan os.Signal, 1)
+
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
@@ -102,6 +97,18 @@ type Executor struct {
 	// TLS tunnel state
 	tlsTunnelActive bool // true after port switch; gates tunnel behaviors
 	lmConnected     bool // tracks if LMS connection is active (for TLS tunnel persistence)
+
+	// lmeStream carries individual APF_CHANNEL_DATA chunks from the AMT side
+	// during LME TLS-tunnel mode; lmeStreamForwarder concatenates and pushes
+	// them into e.data so the main receive loop sees one delivery per RPS
+	// round-trip. nil outside LME tunnel mode.
+	lmeStream chan []byte
+
+	// lmeListenDone is closed when the current persistent LME tunnel Listen
+	// goroutine exits. stopLMEListen waits on it before opening a new session
+	// so two Receive loops never race on the same HECI handle. nil when no
+	// tunnel listener has been started.
+	lmeListenDone chan struct{}
 }
 type ExecutorConfig struct {
 	URL              string
@@ -250,10 +257,18 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 		return false
 	}
 
-	// Detect TLS ClientHello - close existing connection so firmware can renegotiate
+	// Detect TLS ClientHello - close existing connection so firmware can renegotiate.
+	// In LME mode the per-TLS-session resource is just the APF channel (already
+	// torn down by AMT on the previous CHANNEL_CLOSE, which cleared lmConnected
+	// via lmeStreamForwarder); the HECI handle owns the tcpip-forward port
+	// registrations from Initialize() and must stay open across TLS sessions.
 	if len(msg.Payload) >= 6 && msg.Payload[0] == 0x16 && msg.Payload[5] == 0x01 && e.lmConnected {
 		log.Debug("TLS ClientHello detected, closing existing connection for new handshake")
-		e.localManagement.Close()
+
+		if !e.isLME {
+			e.localManagement.Close()
+		}
+
 		e.lmConnected = false
 	}
 
@@ -261,10 +276,18 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 
 	// Set up connection and listener based on transport mode
 	if e.isLME {
-		if err := e.prepareLME(); err != nil {
-			e.lastError = err
+		if e.tlsTunnelActive {
+			if err := e.prepareLMETunnel(); err != nil {
+				e.lastError = err
 
-			return true
+				return true
+			}
+		} else {
+			if err := e.prepareLME(); err != nil {
+				e.lastError = err
+
+				return true
+			}
 		}
 	} else if e.tlsTunnelActive {
 		if err := e.prepareLMSTunnel(); err != nil {
@@ -297,11 +320,49 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 	// Use longer timeout for TLS tunnel mode (AMT may take 60+ seconds for TLS restart)
 	responseTimeout := utils.AMTResponseTimeout * time.Second
 	if e.tlsTunnelActive {
-		responseTimeout = 90 * time.Second
+		responseTimeout = utils.TLSTunnelResponseTimeout * time.Second
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), responseTimeout)
 	defer cancel()
+
+	// In LME TLS-tunnel mode, bound the wait for AMT's first response byte on
+	// EVERY round, mirroring the LMS reference path (lm.LMSConnection.Listen,
+	// which uses a flat 2s first-byte read timeout regardless of TLS record
+	// type). A TLS handshake has rounds that legitimately produce zero AMT-side
+	// bytes, and the record type does NOT reliably identify them: under TLS 1.2
+	// the silent round is the client's ChangeCipherSpec+Finished (0x14), but
+	// under TLS 1.3 it is the encrypted client Finished, which travels as an
+	// application-data record (0x17) - indistinguishable by first byte from a
+	// WSMAN request. Conversely a HelloRetryRequest round opens with a 0x14 CCS
+	// yet still expects the server's certificate flight. Gating on the record
+	// type therefore both misses the TLS 1.3 Finished (hanging the full response
+	// timeout) and risks yielding on a HRR round. AMT's real responses arrive
+	// well within this window, so a flat first-byte timeout yields promptly on
+	// the genuinely-silent round while still forwarding every real reply. The
+	// persistent Listen goroutine stays alive across the yield, so a slightly
+	// late response is not lost.
+	var firstByteC <-chan time.Time
+
+	if e.isLME && e.tlsTunnelActive {
+		firstByteTimer := time.NewTimer(lmeTunnelFirstByteTimeout)
+		defer firstByteTimer.Stop()
+
+		firstByteC = firstByteTimer.C
+	}
+
+	// In LME TLS-tunnel mode also watch the persistent listener's done channel.
+	// AMT ends a TLS session by closing the APF channel, but it sometimes sends
+	// the CHANNEL_CLOSE with RecipientChannel 0, which the APF layer can't key to
+	// our channel, so no stream-close sentinel reaches the receive path. The
+	// listener itself always exits on CHANNEL_CLOSE though; observing that exit
+	// here lets us re-handshake immediately instead of blocking until the
+	// response timeout.
+	var listenDoneC <-chan struct{}
+
+	if e.isLME && e.tlsTunnelActive {
+		listenDoneC = e.lmeListenDone
+	}
 
 	for {
 		select {
@@ -309,7 +370,15 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 			if len(dataFromLM) == 0 {
 				if e.tlsTunnelActive {
 					log.Warn("Empty response from LMS - sending connection_reset")
-					e.localManagement.Close()
+
+					// LME tunnel mode: don't close the HECI handle (it owns the
+					// tcpip-forward registrations); just mark the per-channel
+					// state stale so the next prepareLMETunnel opens a fresh
+					// APF channel for the new TLS session.
+					if !e.isLME {
+						e.localManagement.Close()
+					}
+
 					e.lmConnected = false
 
 					resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
@@ -319,17 +388,39 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				return false
 			}
 
-			log.Debug("Received response from LME/LMS, forwarding to RPS")
-			e.HandleDataFromLM(dataFromLM)
-			log.Debug("Response sent to RPS, waiting for next RPS message")
+			// In LME TLS-tunnel mode a single TLS round-trip arrives as multiple
+			// APF_CHANNEL_DATA chunks (e.g. ServerHello, Certificate, SKE, …).
+			// RPS's TLS-tunnel manager treats each tls_data message as a discrete
+			// unit, so forwarding each chunk separately hands it fragmented TLS
+			// records and the handshake fails ("Failed to initialize TLS tunnel").
+			// The LMS path (lm.LMSConnection.Listen) coalesces all bytes received
+			// within an idle window into one message; mirror that here by draining
+			// additional chunks and concatenating them before a single forward.
+			if e.isLME && e.tlsTunnelActive {
+				coalesced, channelClosed := e.coalesceLMETunnelResponse(dataFromLM)
 
-			if e.isLME {
-				e.waitGroup.Wait()
+				log.Debugf("Received response from LME (coalesced %d bytes), forwarding to RPS", len(coalesced))
+				e.HandleDataFromLM(coalesced)
+				log.Debug("Response sent to RPS, waiting for next RPS message")
 
-				if bytes.Contains(msg.Payload, []byte(soapActionGenerateKeyPair)) {
-					log.Debugf("LME: pausing %s after GenerateKeyPair to let AMT settle before next channel open", lmePostKeygenPause)
-					time.Sleep(lmePostKeygenPause)
+				if channelClosed {
+					log.Debug("LME tunnel: APF channel closed by AMT mid-session; asking RPS to re-handshake")
+
+					e.lmConnected = false
+
+					resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
+					e.server.Send(resetMsg)
+
+					return false
 				}
+			} else {
+				log.Debug("Received response from LME/LMS, forwarding to RPS")
+				e.HandleDataFromLM(dataFromLM)
+				log.Debug("Response sent to RPS, waiting for next RPS message")
+			}
+
+			if e.isLME && !e.tlsTunnelActive {
+				e.waitGroup.Wait()
 			}
 
 			// LME holds a persistent HECI handle whose tcpip-forward registrations
@@ -367,7 +458,10 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 				log.Error("LMS error: ", errFromLMS)
 
 				if e.tlsTunnelActive {
-					e.localManagement.Close()
+					if !e.isLME {
+						e.localManagement.Close()
+					}
+
 					e.lmConnected = false
 
 					resetMsg := e.payload.CreateMessageResponse([]byte("lms_error"), MethodConnectionReset)
@@ -380,6 +474,37 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 
 				return true
 			}
+		case <-firstByteC:
+			// No first response byte from AMT within the first-byte window for
+			// this LME TLS-tunnel round. AMT's real responses arrive well inside
+			// this window, so silence here means this is an idle handshake round
+			// (e.g. after RPS's client Finished). Yield to RPS keeping the
+			// persistent APF channel and Listen goroutine alive so the next
+			// pipelined tls_data message rides the same TLS session, mirroring
+			// the LMS ErrLMSReadTimeoutNoData behavior.
+			log.Trace("No LME tunnel data within first-byte window; yielding to RPS")
+
+			return false
+		case <-listenDoneC:
+			// The persistent tunnel listener exited: AMT closed the APF channel
+			// (and thus this TLS session). When the close carries RecipientChannel
+			// 0 the APF layer can't match it to our channel, so no stream-close
+			// sentinel is produced and the plain read wait would block until the
+			// response timeout. Flush any final bytes the listener forwarded
+			// before exiting, hand them to RPS, then ask RPS to re-handshake.
+			if final := e.drainLMETunnelData(); len(final) > 0 {
+				log.Debugf("Received final response from LME (%d bytes) before channel close, forwarding to RPS", len(final))
+				e.HandleDataFromLM(final)
+			}
+
+			log.Debug("LME tunnel: listener exited (AMT closed channel); asking RPS to re-handshake")
+
+			e.lmConnected = false
+
+			resetMsg := e.payload.CreateMessageResponse([]byte("connection_closed"), MethodConnectionReset)
+			e.server.Send(resetMsg)
+
+			return false
 		case <-timeoutCtx.Done():
 			// Timeout waiting for response from AMT/LME
 			// This indicates AMT is not responding - treat as an error
@@ -398,39 +523,72 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 func (e *Executor) prepareLME() error {
 	log.Debug("LME: Opening new APF channel for this request")
 
-	// Fresh handshake WaitGroup per request: if a prior Listen exited without
-	// signaling Done(), the old WG is abandoned rather than deadlocking this one.
-	handshake := e.resetHandshake()
+	var lastErr error
 
-	err := e.localManagement.Connect()
-	if err != nil {
-		return fmt.Errorf("failed to open LME channel: %w", err)
-	}
+	for attempt := 0; attempt < lmeChannelOpenAttempts; attempt++ {
+		// Fresh handshake WaitGroup per attempt: if a prior Listen exited
+		// without signaling Done(), the old WG is abandoned rather than
+		// deadlocking this one.
+		handshake := e.resetHandshake()
 
-	go e.localManagement.Listen()
-
-	// Bounded wait so a Listen goroutine that exits early on a HECI error
-	// can't block this loop forever. OPEN_FAILURE also signals Done().
-	handshakeDone := make(chan struct{})
-
-	go func() {
-		handshake.Wait()
-		close(handshakeDone)
-	}()
-
-	select {
-	case <-handshakeDone:
-		log.Trace("Channel open confirmation received")
-	case errFromLMS := <-e.errors:
-		if errFromLMS != nil {
-			return fmt.Errorf("LME error during channel open: %w", errFromLMS)
+		err := e.localManagement.Connect()
+		if err != nil {
+			return fmt.Errorf("failed to open LME channel: %w", err)
 		}
-	case <-time.After(handshakeTimeout):
-		return fmt.Errorf("timed out waiting for APF channel open after %s", handshakeTimeout)
+
+		go e.localManagement.Listen()
+
+		// Bounded wait so a Listen goroutine that exits early on a HECI error
+		// can't block this loop forever. OPEN_FAILURE also signals Done().
+		handshakeDone := lm.WaitChan(handshake)
+
+		select {
+		case <-handshakeDone:
+			log.Trace("Channel open confirmation received")
+
+			return nil
+		case errFromLMS := <-e.errors:
+			if errFromLMS == nil {
+				return nil
+			}
+
+			// Older AMT firmware (notably AMT16) tears down its tcpip-forward
+			// bindings when idle between WSMAN requests and re-advertises them
+			// on the next request. A CHANNEL_OPEN that races that teardown is
+			// rejected with APF_CHANNEL_OPEN_FAILURE (reason code 1) even though
+			// the forward is restored microseconds later - the re-advertising
+			// tcpip-forward requests arrive before the failure itself. Retry the
+			// open; the Listen goroutine has already exited on the failure, so a
+			// fresh Connect+Listen races nothing, and by now the port is bound.
+			if errors.Is(errFromLMS, apf.ErrChannelOpenFailure) && attempt < lmeChannelOpenAttempts-1 {
+				lastErr = errFromLMS
+
+				log.Debugf("APF channel open rejected (%v); retrying", errFromLMS)
+				time.Sleep(lmeChannelOpenRetryDelay)
+
+				continue
+			}
+
+			return fmt.Errorf("LME error during channel open: %w", errFromLMS)
+		case <-time.After(handshakeTimeout):
+			return fmt.Errorf("timed out waiting for APF channel open after %s", handshakeTimeout)
+		}
 	}
 
-	return nil
+	return fmt.Errorf("LME error during channel open: %w", lastErr)
 }
+
+// lmeChannelOpenAttempts bounds how many times prepareLME re-issues an
+// APF_CHANNEL_OPEN after AMT rejects it with APF_CHANNEL_OPEN_FAILURE. Older
+// firmware drops and re-advertises its tcpip-forward bindings between idle
+// requests, so the first open of a request can race the teardown; a couple of
+// retries lets the now-rebound port accept the channel.
+const lmeChannelOpenAttempts = 3
+
+// lmeChannelOpenRetryDelay is the brief settle wait between channel-open retries
+// in prepareLME, giving AMT time to finish re-advertising the tcpip-forward
+// bindings before the next CHANNEL_OPEN.
+const lmeChannelOpenRetryDelay = 250 * time.Millisecond
 
 // resetHandshake installs a fresh WaitGroup on the LME session so each request
 // starts from a known-zero counter; a stale Done() from an abandoned Listen
@@ -438,13 +596,142 @@ func (e *Executor) prepareLME() error {
 func (e *Executor) resetHandshake() *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
 
-	if lmec, ok := e.localManagement.(*lm.LMEConnection); ok && lmec.Session != nil {
-		lmec.Session.WaitGroup = wg
+	if lmec, ok := e.localManagement.(*lm.LMEConnection); ok {
+		wg = lmec.ResetHandshake()
 	}
 
 	e.waitGroup = wg
 
 	return wg
+}
+
+// lmeTunnelIdleWindow is how long the LME tunnel receive loop waits for more
+// APF_CHANNEL_DATA chunks after one arrives, before returning to wait for the
+// next RPS message. Long enough to coalesce TLS handshake fragments, short
+// enough not to add noticeable latency to each round-trip.
+const (
+	lmeTunnelIdleWindow = 200 * time.Millisecond // lmeTunnelCloseWait is how long the LME tunnel receive loop keeps waiting,
+	// after AMT's response data has stopped arriving, specifically for the trailing
+	// APF_CHANNEL_CLOSE that AMT sends after each HTTP/WSMAN response in
+	// TLS-enforced mode (Connection: close — every WSMAN call gets its own channel
+	// and TLS session). Catching that close in the same round lets us tell RPS to
+	// re-handshake immediately; if we miss it (it arrives after we have already
+	// yielded back to RPS) the close sentinel sits unconsumed and RPS stalls until
+	// its own multi-second timeout before re-handshaking. AMT emits the close
+	// within a few hundred ms of the response, so this returns early in practice;
+	// the cap only applies on the rare round where AMT keeps the channel open.
+	lmeTunnelCloseWait = 1500 * time.Millisecond
+)
+
+// lmeTunnelFirstByteTimeout bounds how long the LME tunnel receive loop waits
+// for the FIRST byte of AMT's response to a forwarded tls_data message before
+// yielding back to RPS. It is the LME analog of the LMS first-byte read
+// timeout (lm.LMSConnection.Listen): in a TLS 1.3 handshake some rounds are
+// legitimately silent on AMT's side (e.g. right after RPS's client Finished,
+// AMT stays quiet until it receives the encrypted application request), and
+// RPS pipelines the next message rather than waiting for a reply. Without this
+// bound the loop blocks on the HECI read timeout (HeciReadTimeout, ~3s), which
+// exceeds RPS's TLS-operation timeout (~12s → GatewayTimeoutError) and lets the
+// persistent Listen goroutine exit, stranding the session.
+//
+// 3s is hardware-validated (AMT16-21, LME) and must not be lowered blindly: a
+// shorter window clips legitimate replies whose first byte lands close to the
+// boundary, and yielding early lets AMT's real response interleave with RPS's
+// pipelined next message, desynchronizing the tunneled TLS stream and failing
+// activation ("Unknown error has occurred / TLSConfiguration Configured"). Kept
+// above AMT's near-1s real first-byte latency and below RPS's TLS-op timeout.
+// The persistent Listen keeps running across this yield, so a slightly-late
+// real response is still read on the next round. Overridable via
+// RPC_LME_FIRST_BYTE_MS for hardware that needs a different margin.
+var lmeTunnelFirstByteTimeout = time.Duration(envInt("RPC_LME_FIRST_BYTE_MS", 3000)) * time.Millisecond
+
+// lmeListenStopTimeout bounds how long stopLMEListen waits for the previous
+// session's persistent Listen goroutine to exit after StopListen is signaled.
+// The listener re-checks the stop signal once per HECI read cycle
+// (HeciReadTimeout), so a couple of cycles is ample; we cap it low so a
+// listener that is wedged in a blocked Receive can't add the full handshake
+// timeout of latency to every TLS re-handshake (AMT19 opens a fresh channel,
+// and thus a fresh session, for every WSMAN call).
+var lmeListenStopTimeout = (utils.HeciReadTimeout + 1) * time.Second
+
+// lmeTunnelStreamBuffer sizes the per-channel stream queue between the APF
+// processor and the executor forwarder. AMT chunks ServerHello+Certificate
+// into ~5-10 frames; 32 is plenty of headroom for one round-trip.
+const lmeTunnelStreamBuffer = 32
+
+// lmeTunnelOpenAttempts bounds how many times prepareLMETunnel re-opens the APF
+// channel when the MEI link drops mid-open. AMT tears the connection down after
+// a channel close, so the first re-open after a re-handshake can race a HECI
+// reinit that loses the CHANNEL_OPEN; replaying the handshake and retrying
+// recovers it. A couple of retries is ample - the reinit settles immediately.
+const lmeTunnelOpenAttempts = 3
+
+// drainLMEChunks collects APF_CHANNEL_DATA chunks belonging to one TLS round
+// from e.data into a single payload, starting from initial. It resets an idle
+// timer (window idle) on every chunk and returns once the queue stays idle for
+// a full window or the forwarder's zero-length channel-closed sentinel arrives
+// (sawSentinel true). When closeWait is non-zero the idle timeout is extended
+// once to closeWait - specifically to catch AMT's trailing APF_CHANNEL_CLOSE -
+// before returning; pass closeWait == 0 to return on the first idle timeout.
+func (e *Executor) drainLMEChunks(initial []byte, idle, closeWait time.Duration) (coalesced []byte, sawSentinel bool) {
+	coalesced = initial
+	window := idle
+	timer := time.NewTimer(window)
+
+	defer timer.Stop()
+
+	for {
+		select {
+		case more := <-e.data:
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			if len(more) == 0 {
+				// Forwarder sentinel: AMT closed the APF channel.
+				return coalesced, true
+			}
+
+			coalesced = append(coalesced, more...)
+			window = idle
+			timer.Reset(window)
+		case <-timer.C:
+			if closeWait == 0 || window == closeWait {
+				// No close-wait extension requested, or it already elapsed.
+				return coalesced, false
+			}
+
+			// Response data has stopped; extend the wait once, specifically to
+			// catch AMT's trailing channel close so RPS can re-handshake
+			// immediately instead of stalling until its own timeout.
+			window = closeWait
+			timer.Reset(window)
+		}
+	}
+}
+
+// coalesceLMETunnelResponse drains all APF_CHANNEL_DATA chunks belonging to one
+// TLS round (the first chunk is passed in) and then waits briefly for the
+// trailing APF_CHANNEL_CLOSE that AMT sends after each HTTP/WSMAN response in
+// TLS-enforced mode. RPS's TLS-tunnel manager treats each tls_data message as a
+// discrete unit, so all chunks of a round must be concatenated into a single
+// forward (mirroring lm.LMSConnection.Listen). It returns the coalesced payload
+// and whether AMT closed the channel.
+func (e *Executor) coalesceLMETunnelResponse(first []byte) (coalesced []byte, channelClosed bool) {
+	return e.drainLMEChunks(first, lmeTunnelIdleWindow, lmeTunnelCloseWait)
+}
+
+// drainLMETunnelData collects any APF_CHANNEL_DATA chunks the tunnel forwarder
+// has already queued into e.data (e.g. AMT's final response that arrived just
+// before it closed the channel) without blocking on new AMT traffic. It is used
+// when the persistent listener has exited (AMT closed the channel) to flush a
+// trailing response to RPS before asking it to re-handshake. It returns once the
+// queue stays idle for one lmeTunnelIdleWindow or the forwarder's zero-length
+// channel-closed sentinel arrives.
+func (e *Executor) drainLMETunnelData() []byte {
+	coalesced, _ := e.drainLMEChunks(nil, lmeTunnelIdleWindow, 0)
+
+	return coalesced
 }
 
 // prepareLMSTunnel ensures the persistent tunnel connection is ready and starts a listener.
@@ -473,6 +760,175 @@ func (e *Executor) prepareLMS() error {
 	go e.localManagement.Listen()
 
 	return nil
+}
+
+// prepareLMETunnel opens the LME APF channel ONCE, wires the apf session's
+// StreamDataBuffer so CHANNEL_DATA chunks stream out as they arrive (instead
+// of being buffered until CHANNEL_CLOSE), and starts a single persistent
+// Listen goroutine plus a forwarder that pipes the stream into e.data. The
+// same channel is reused for every subsequent RPS tls_data write so the TLS
+// session stays alive across handshake messages.
+func (e *Executor) prepareLMETunnel() error {
+	if e.lmConnected {
+		return nil
+	}
+
+	lmec, ok := e.localManagement.(*lm.LMEConnection)
+	if !ok {
+		return fmt.Errorf("LME tunnel requires *lm.LMEConnection")
+	}
+
+	// Retire any previous session's persistent listener before opening a new
+	// channel so we never run two Receive loops on the same HECI handle.
+	e.stopLMEListen(lmec)
+
+	// Drain any leftover bytes or sentinels left in e.data by the previous
+	// session's forwarder so the next receive loop doesn't treat them as part
+	// of the new TLS handshake response.
+drain:
+	for {
+		select {
+		case <-e.data:
+		default:
+			break drain
+		}
+	}
+
+	e.lmeStream = make(chan []byte, lmeTunnelStreamBuffer)
+	lmec.EnableTunnel(e.lmeStream)
+
+	log.Debug("LME tunnel: opening persistent APF channel for TLS session")
+
+	for attempt := 0; attempt < lmeTunnelOpenAttempts; attempt++ {
+		handshake := e.resetHandshake()
+
+		if err := lmec.Connect(); err != nil {
+			return fmt.Errorf("failed to open LME channel: %w", err)
+		}
+
+		// The tunnel Listen goroutine is persistent: it spans every TLS round of
+		// this session. lmeListenDone lets stopLMEListen join it before the next
+		// session opens.
+		listenDone := make(chan struct{})
+		e.lmeListenDone = listenDone
+
+		go func() {
+			lmec.Listen()
+			close(listenDone)
+		}()
+
+		handshakeDone := lm.WaitChan(handshake)
+
+		confirmed := false
+
+		select {
+		case <-handshakeDone:
+			confirmed = true
+		case errFromLMS := <-e.errors:
+			if errors.Is(errFromLMS, heci.ErrDeviceReinitialized) {
+				// AMT tore the MEI link down after the previous channel close;
+				// the HECI layer transparently reopened it, so the firmware
+				// replayed its APF init and the CHANNEL_OPEN we just sent was
+				// lost. Wait for the listener to exit, complete the replayed
+				// handshake, then retry the channel open on the fresh session.
+				<-listenDone
+
+				e.lmeListenDone = nil
+
+				log.Debug("LME tunnel: MEI reinitialized during channel open; replaying APF handshake and retrying")
+
+				if err := lmec.ReestablishAPF(); err != nil {
+					return fmt.Errorf("failed to re-establish APF after reinit: %w", err)
+				}
+
+				continue
+			}
+
+			if errFromLMS != nil {
+				return fmt.Errorf("LME error during channel open: %w", errFromLMS)
+			}
+
+			// A nil error signals the channel is up (legacy behavior).
+			confirmed = true
+		case <-time.After(handshakeTimeout):
+			return fmt.Errorf("timed out waiting for LME tunnel APF channel open after %s", handshakeTimeout)
+		}
+
+		if confirmed {
+			log.Trace("LME tunnel: CHANNEL_OPEN_CONFIRMATION received")
+
+			e.lmConnected = true
+
+			go e.lmeStreamForwarder()
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("LME tunnel: APF channel open failed after %d attempts", lmeTunnelOpenAttempts)
+}
+
+// stopLMEListen retires the persistent tunnel Listen goroutine from a previous
+// TLS session and waits for it to exit, so a new session never races a second
+// Receive loop against it on the same HECI handle. No-op when no listener is
+// tracked (first session) or it has already exited.
+func (e *Executor) stopLMEListen(lmec *lm.LMEConnection) {
+	if e.lmeListenDone == nil {
+		return
+	}
+
+	lmec.StopListen()
+
+	select {
+	case <-e.lmeListenDone:
+	case <-time.After(lmeListenStopTimeout):
+		log.Warn("LME tunnel: timed out waiting for previous listener to exit")
+	}
+
+	e.lmeListenDone = nil
+}
+
+// lmeStreamForwarder pipes streaming CHANNEL_DATA chunks into the existing
+// e.data channel so the receive loop in HandleDataFromRPS picks them up the
+// same way it picks up LMS reads. Exits when the stream channel is closed
+// (apf processor closes it on CHANNEL_CLOSE for the active channel). On exit
+// it pushes a zero-length sentinel into e.data so the receive loop knows the
+// AMT-side TLS session is gone and must trigger a connection_reset to RPS.
+func (e *Executor) lmeStreamForwarder() {
+	// Capture the stream we own at start so a forwarder for a superseded
+	// channel can detect that prepareLMETunnel has already moved on and
+	// exit silently instead of clobbering the new session's state.
+	myStream := e.lmeStream
+
+	for chunk := range myStream {
+		if len(chunk) == 0 {
+			continue
+		}
+
+		e.data <- chunk
+	}
+
+	log.Debug("LME tunnel: stream forwarder exited (channel closed)")
+
+	if e.lmeStream != myStream {
+		// A newer forwarder has taken over; don't reset lmConnected or push
+		// a sentinel that would trigger a spurious connection_reset on the
+		// fresh channel.
+		log.Debug("LME tunnel: stale forwarder exit ignored (superseded)")
+
+		return
+	}
+
+	// AMT closed the APF channel — the TLS state on its side is gone. Mark
+	// the LME tunnel as disconnected so the next RPS write reopens a fresh
+	// channel, and push a zero-length sentinel so the receive loop falls
+	// through to the connection_reset path that asks RPS to re-handshake.
+	e.lmConnected = false
+
+	select {
+	case e.data <- nil:
+	default:
+	}
 }
 
 func (e *Executor) handlePortSwitch(jsonData string) error {
@@ -505,7 +961,7 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 	// HECI/APF and the only thing that changes is the AMT-side port future
 	// CHANNEL_OPENs target. Close-and-redial would dial a 127.0.0.1:16993
 	// socket that isn't listening (that's why we're on LME in the first
-	// place). Keep the LME handle, honour the delay, flip the port.
+	// place). Keep the LME handle, honor the delay, flip the port.
 	if e.isLME {
 		if err := waitWithSignal(time.Duration(delaySeconds) * time.Second); err != nil {
 			return err
@@ -565,7 +1021,7 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 	)
 
 	// Test connection with retries
-	maxRetries := 5
+	maxRetries := utils.LMEPortSwitchMaxRetries
 
 	var connectErr error
 
@@ -576,7 +1032,7 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 		}
 
 		log.Warnf("Port switch: LMS connect attempt %d/%d failed: %v", i+1, maxRetries, connectErr)
-		time.Sleep(5 * time.Second)
+		time.Sleep(utils.LMEPortSwitchRetryDelay * time.Second)
 	}
 
 	if connectErr != nil {

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -5,12 +5,14 @@
 package rps
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -28,8 +30,65 @@ var handshakeTimeout = (utils.HeciReadTimeout + 15) * time.Second
 // maxPortSwitchDelaySeconds caps the AMT TLS-restart wait that RPS asks for via
 // the port_switch payload. The server-supplied value is clamped to this maximum
 // to bound how long the activation loop can be blocked on a (possibly hostile
-// or buggy) server-controlled delay.
-const maxPortSwitchDelaySeconds = 60
+// or buggy) server-controlled delay. Overridable via RPC_PORT_SWITCH_MAX_DELAY.
+var maxPortSwitchDelaySeconds = envInt("RPC_PORT_SWITCH_MAX_DELAY", 60)
+
+// extraPortSwitchDelaySeconds is added on top of the server-requested delay
+// (after clamping). Useful when AMT's TLS subsystem needs more time than RPS
+// expects to bind the freshly-committed server cert to port 16993; raise this
+// if you see "Failed to establish TLS tunnel connection" errors immediately
+// after port_switch. Overridable via RPC_PORT_SWITCH_EXTRA_DELAY.
+var extraPortSwitchDelaySeconds = envInt("RPC_PORT_SWITCH_EXTRA_DELAY", 0)
+
+// lmePostKeygenPause: AMT 18.x briefly drops the LME MEI client after
+// GenerateKeyPair persists the new key; pausing here pre-empts an ENODEV on
+// the next CHANNEL_OPEN that would otherwise cost ~6s re-handshake.
+// Overridable (milliseconds) via RPC_LME_POST_KEYGEN_PAUSE_MS.
+var lmePostKeygenPause = time.Duration(envInt("RPC_LME_POST_KEYGEN_PAUSE_MS", 750)) * time.Millisecond
+
+const soapActionGenerateKeyPair = "AMT_PublicKeyManagementService/GenerateKeyPair"
+
+// envInt returns the integer value of env var name, or def if unset/invalid.
+func envInt(name string, def int) int {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Warnf("ignoring invalid %s=%q: %v", name, v, err)
+
+		return def
+	}
+
+	return n
+}
+
+// waitWithSignal sleeps for d but returns early with an error if SIGINT/SIGTERM
+// arrives, so the activation loop can abort promptly on Ctrl+C rather than
+// being held by a server-requested delay.
+func waitWithSignal(d time.Duration) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	timer := time.NewTimer(d)
+
+	select {
+	case <-timer.C:
+		return nil
+	case sig := <-sigCh:
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+
+		return fmt.Errorf("port-switch wait interrupted by %v", sig)
+	}
+}
 
 type Executor struct {
 	server          AMTActivationServer
@@ -262,6 +321,11 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 
 			if e.isLME {
 				e.waitGroup.Wait()
+
+				if bytes.Contains(msg.Payload, []byte(soapActionGenerateKeyPair)) {
+					log.Debugf("LME: pausing %s after GenerateKeyPair to let AMT settle before next channel open", lmePostKeygenPause)
+					time.Sleep(lmePostKeygenPause)
+				}
 			}
 
 			// LME holds a persistent HECI handle whose tcpip-forward registrations
@@ -425,7 +489,48 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 		delaySeconds = maxPortSwitchDelaySeconds
 	}
 
-	log.Infof("Port switch: closing LMS connection, waiting %ds for AMT TLS restart", delaySeconds)
+	if extraPortSwitchDelaySeconds > 0 {
+		log.Infof("Port switch: adding %ds extra delay (RPC_PORT_SWITCH_EXTRA_DELAY)", extraPortSwitchDelaySeconds)
+
+		delaySeconds += extraPortSwitchDelaySeconds
+	}
+
+	log.Infof("Port switch: waiting %ds for AMT TLS restart", delaySeconds)
+
+	// In LME mode there is no LMS daemon to reconnect to; transport stays on
+	// HECI/APF and the only thing that changes is the AMT-side port future
+	// CHANNEL_OPENs target. Close-and-redial would dial a 127.0.0.1:16993
+	// socket that isn't listening (that's why we're on LME in the first
+	// place). Keep the LME handle, honour the delay, flip the port.
+	if e.isLME {
+		if err := waitWithSignal(time.Duration(delaySeconds) * time.Second); err != nil {
+			return err
+		}
+
+		if lmec, ok := e.localManagement.(*lm.LMEConnection); ok {
+			port, perr := strconv.ParseUint(psPayload.Port, 10, 32)
+			if perr != nil {
+				return fmt.Errorf("port switch: invalid port %q: %w", psPayload.Port, perr)
+			}
+
+			lmec.SetPort(uint32(port))
+		}
+
+		e.tlsTunnelActive = true
+
+		log.Info("Port switch: LME retargeted to port ", psPayload.Port)
+
+		ackMsg := e.payload.CreateMessageResponse([]byte("ok"), MethodPortSwitchAck)
+		if err := e.server.Send(ackMsg); err != nil {
+			return err
+		}
+
+		log.Info("Port switch: sent port_switch_ack to RPS")
+
+		return nil
+	}
+
+	log.Infof("Port switch: closing LMS connection")
 
 	// Close existing LMS connection
 	e.localManagement.Close()
@@ -434,21 +539,9 @@ func (e *Executor) handlePortSwitch(jsonData string) error {
 	// Wait for AMT to restart its TLS subsystem. Use a cancellable wait so a
 	// user interrupt (Ctrl+C / SIGTERM) can abort the activation loop promptly
 	// instead of being delayed by the full sleep.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-
-	timer := time.NewTimer(time.Duration(delaySeconds) * time.Second)
-
-	select {
-	case <-timer.C:
-	case <-sigCh:
-		timer.Stop()
-		signal.Stop(sigCh)
-
-		return fmt.Errorf("port switch wait interrupted")
+	if err := waitWithSignal(time.Duration(delaySeconds) * time.Second); err != nil {
+		return err
 	}
-
-	signal.Stop(sigCh)
 
 	// Create new LMS connection channels
 	lmDataChannel := make(chan []byte)

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -947,10 +947,14 @@ func (e *Executor) lmeStreamForwarder(stream <-chan []byte, stop <-chan struct{}
 				log.Debug("LME tunnel: stream forwarder exited (channel closed)")
 
 				// AMT closed the APF channel. Push a zero-length sentinel so the
-				// receive loop asks RPS to re-handshake.
+				// receive loop asks RPS to re-handshake. Use non-blocking send with
+				// brief timeout fallback to avoid blocking if receiver is not active
+				// (e.g., during session teardown), while ensuring sentinel is
+				// delivered in normal operation (receive loop listening on e.data).
 				select {
 				case e.data <- nil:
-				default:
+				case <-time.After(100 * time.Millisecond):
+					log.Debug("LME tunnel: stream close sentinel dropped (no receiver)")
 				}
 
 				return

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -135,13 +135,17 @@ func NewExecutor(config ExecutorConfig) (Executor, error) {
 	// TEST CONNECTION TO SEE IF LMS EXISTS
 	err := client.localManagement.Connect()
 	if err != nil {
-		if config.LocalTlsEnforced {
-			return client, utils.LMSConnectionFailed
-		}
-		// client.localManagement.Close()
-		log.Trace("LMS not running.  Using LME Connection\n")
+		log.Tracef("LMS dial failed (%v); falling back to LME (in-band HECI/APF)", err)
 
-		client.localManagement = lm.NewLMEConnection(lmDataChannel, lmErrorChannel, client.waitGroup)
+		lme := lm.NewLMEConnection(lmDataChannel, lmErrorChannel, client.waitGroup)
+		// On TLS-enforced AMT the active local port is 16993; aim the first
+		// CHANNEL_OPEN there so RPS doesn't have to issue a port_switch just
+		// to get past the activation handshake.
+		if config.LocalTlsEnforced {
+			lme.SetPort(16993)
+		}
+
+		client.localManagement = lme
 		client.isLME = true
 		client.localManagement.Initialize()
 	} else {

--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -56,6 +56,12 @@ func envInt(name string, def int) int {
 		return def
 	}
 
+	if n < 0 {
+		log.Warnf("ignoring negative %s=%q", name, v)
+
+		return def
+	}
+
 	return n
 }
 
@@ -99,9 +105,9 @@ type Executor struct {
 	lmConnected     bool // tracks if LMS connection is active (for TLS tunnel persistence)
 
 	// lmeStream carries individual APF_CHANNEL_DATA chunks from the AMT side
-	// during LME TLS-tunnel mode; lmeStreamForwarder concatenates and pushes
-	// them into e.data so the main receive loop sees one delivery per RPS
-	// round-trip. nil outside LME tunnel mode.
+	// during LME TLS-tunnel mode; lmeStreamForwarder forwards them into e.data,
+	// and HandleDataFromRPS coalesces chunks per RPS round-trip before
+	// forwarding to RPS. nil outside LME tunnel mode.
 	lmeStream chan []byte
 
 	// lmeListenDone is closed when the current persistent LME tunnel Listen
@@ -109,6 +115,12 @@ type Executor struct {
 	// so two Receive loops never race on the same HECI handle. nil when no
 	// tunnel listener has been started.
 	lmeListenDone chan struct{}
+
+	// lmeForwarderStop/lmeForwarderDone control the APF stream forwarder
+	// goroutine lifecycle so a superseded session cannot leave a stale forwarder
+	// blocked forever on a stream channel that never closes.
+	lmeForwarderStop chan struct{}
+	lmeForwarderDone chan struct{}
 }
 type ExecutorConfig struct {
 	URL              string
@@ -154,7 +166,9 @@ func NewExecutor(config ExecutorConfig) (Executor, error) {
 
 		client.localManagement = lme
 		client.isLME = true
-		client.localManagement.Initialize()
+		if err := client.localManagement.Initialize(); err != nil {
+			return Executor{}, fmt.Errorf("failed to initialize LME connection: %w", err)
+		}
 	} else {
 		log.Trace("Using existing LMS\n")
 		client.localManagement.Close()
@@ -610,7 +624,9 @@ func (e *Executor) resetHandshake() *sync.WaitGroup {
 // next RPS message. Long enough to coalesce TLS handshake fragments, short
 // enough not to add noticeable latency to each round-trip.
 const (
-	lmeTunnelIdleWindow = 200 * time.Millisecond // lmeTunnelCloseWait is how long the LME tunnel receive loop keeps waiting,
+	lmeTunnelIdleWindow = 200 * time.Millisecond
+
+	// lmeTunnelCloseWait is how long the LME tunnel receive loop keeps waiting,
 	// after AMT's response data has stopped arriving, specifically for the trailing
 	// APF_CHANNEL_CLOSE that AMT sends after each HTTP/WSMAN response in
 	// TLS-enforced mode (Connection: close — every WSMAN call gets its own channel
@@ -858,8 +874,12 @@ drain:
 			log.Trace("LME tunnel: CHANNEL_OPEN_CONFIRMATION received")
 
 			e.lmConnected = true
+			forwarderStop := make(chan struct{})
+			forwarderDone := make(chan struct{})
+			e.lmeForwarderStop = forwarderStop
+			e.lmeForwarderDone = forwarderDone
 
-			go e.lmeStreamForwarder()
+			go e.lmeStreamForwarder(e.lmeStream, forwarderStop, forwarderDone)
 
 			return nil
 		}
@@ -873,6 +893,8 @@ drain:
 // Receive loop against it on the same HECI handle. No-op when no listener is
 // tracked (first session) or it has already exited.
 func (e *Executor) stopLMEListen(lmec *lm.LMEConnection) {
+	e.stopLMEForwarder()
+
 	if e.lmeListenDone == nil {
 		return
 	}
@@ -888,46 +910,64 @@ func (e *Executor) stopLMEListen(lmec *lm.LMEConnection) {
 	e.lmeListenDone = nil
 }
 
+func (e *Executor) stopLMEForwarder() {
+	if e.lmeForwarderStop == nil || e.lmeForwarderDone == nil {
+		return
+	}
+
+	close(e.lmeForwarderStop)
+
+	select {
+	case <-e.lmeForwarderDone:
+	case <-time.After(lmeListenStopTimeout):
+		log.Warn("LME tunnel: timed out waiting for previous stream forwarder to exit")
+	}
+
+	e.lmeForwarderStop = nil
+	e.lmeForwarderDone = nil
+}
+
 // lmeStreamForwarder pipes streaming CHANNEL_DATA chunks into the existing
 // e.data channel so the receive loop in HandleDataFromRPS picks them up the
 // same way it picks up LMS reads. Exits when the stream channel is closed
 // (apf processor closes it on CHANNEL_CLOSE for the active channel). On exit
 // it pushes a zero-length sentinel into e.data so the receive loop knows the
 // AMT-side TLS session is gone and must trigger a connection_reset to RPS.
-func (e *Executor) lmeStreamForwarder() {
-	// Capture the stream we own at start so a forwarder for a superseded
-	// channel can detect that prepareLMETunnel has already moved on and
-	// exit silently instead of clobbering the new session's state.
-	myStream := e.lmeStream
+func (e *Executor) lmeStreamForwarder(stream <-chan []byte, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
 
-	for chunk := range myStream {
-		if len(chunk) == 0 {
-			continue
+	for {
+		select {
+		case <-stop:
+			log.Debug("LME tunnel: stream forwarder stopped for superseding session")
+
+			return
+		case chunk, ok := <-stream:
+			if !ok {
+				log.Debug("LME tunnel: stream forwarder exited (channel closed)")
+
+				// AMT closed the APF channel. Push a zero-length sentinel so the
+				// receive loop asks RPS to re-handshake.
+				select {
+				case e.data <- nil:
+				default:
+				}
+
+				return
+			}
+
+			if len(chunk) == 0 {
+				continue
+			}
+
+			select {
+			case e.data <- chunk:
+			case <-stop:
+				log.Debug("LME tunnel: stream forwarder stop while forwarding")
+
+				return
+			}
 		}
-
-		e.data <- chunk
-	}
-
-	log.Debug("LME tunnel: stream forwarder exited (channel closed)")
-
-	if e.lmeStream != myStream {
-		// A newer forwarder has taken over; don't reset lmConnected or push
-		// a sentinel that would trigger a spurious connection_reset on the
-		// fresh channel.
-		log.Debug("LME tunnel: stale forwarder exit ignored (superseded)")
-
-		return
-	}
-
-	// AMT closed the APF channel — the TLS state on its side is gone. Mark
-	// the LME tunnel as disconnected so the next RPS write reopens a fresh
-	// channel, and push a zero-length sentinel so the receive loop falls
-	// through to the connection_reset path that asks RPS to re-handshake.
-	e.lmConnected = false
-
-	select {
-	case e.data <- nil:
-	default:
 	}
 }
 

--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -42,6 +42,16 @@ const (
 	errMsgPermissionDenied   = "open /dev/mei0: permission denied"
 	errMsgNoSuchFile         = "open /dev/mei0: no such file or directory"
 	pollWarnLogInterval      = 15 * time.Second
+	// heciConnectAttempts bounds the MEI_CONNECT_CLIENT EBUSY retry loop.
+	// Connect almost always succeeds on retry 1 after a reopen; the extra
+	// attempts only cover the rarer cases where the ME stays busy. The
+	// backoff ramps per attempt (HeciConnectRetryBackoff * (i+1)) so repeated
+	// "mei connect busy" retries are spaced further apart as the ME settles.
+	heciConnectAttempts = 8
+	// guidConnectAttempts bounds the MEI_CONNECT_CLIENT retry loop for the
+	// GUID-targeted clients (InitWithGUID / InitHOTHAM). These paths are not
+	// EBUSY-tuned like initLocked; a small fixed number of attempts is enough.
+	guidConnectAttempts = 3
 )
 
 // PTHI
@@ -82,29 +92,59 @@ func (heci *Driver) Init(useLME, useWD bool) error {
 	return heci.initLocked(useLME, useWD)
 }
 
-func (heci *Driver) initLocked(useLME, useWD bool) error {
-	heci.useLME = useLME
-	heci.useWD = useWD
-	heci.useGUIDClient = false
-
-	var err error
-
-	// Close any previous device handle before reopening
+// openMEIDevice closes any previously opened MEI handle and reopens the device,
+// logging a privilege/availability hint when the open fails. Shared by every
+// Init* entry point so the close-then-reopen and error-classification logic
+// lives in one place.
+func (heci *Driver) openMEIDevice() error {
 	if heci.meiDevice != nil {
 		_ = heci.meiDevice.Close()
 		heci.meiDevice = nil
 	}
 
-	heci.meiDevice, err = os.OpenFile(Device, syscall.O_RDWR, 0)
+	dev, err := os.OpenFile(Device, syscall.O_RDWR, 0)
 	if err != nil {
-		if err.Error() == errMsgPermissionDenied {
+		switch err.Error() {
+		case errMsgPermissionDenied:
 			log.Debug("need administrator privileges")
-		} else if err.Error() == errMsgNoSuchFile {
+		case errMsgNoSuchFile:
 			log.Error("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
-		} else {
-			log.Error("Cannot open MEI Device")
+		default:
+			log.Errorf("Cannot open MEI Device: %v", err)
 		}
 
+		return err
+	}
+
+	heci.meiDevice = dev
+
+	return nil
+}
+
+// parseConnectClientData reads the MEI_CONNECT_CLIENT response out of data and
+// records the negotiated buffer size and protocol version on the driver. Shared
+// by every Init* entry point.
+func (heci *Driver) parseConnectClientData(data CMEIConnectClientData) error {
+	t := MEIConnectClientData{}
+
+	err := binary.Read(bytes.NewBuffer(data.data[:]), binary.LittleEndian, &t)
+	if err != nil {
+		return err
+	}
+
+	heci.bufferSize = t.MaxMessageLength
+	heci.protocolVersion = t.ProtocolVersion
+
+	return nil
+}
+
+func (heci *Driver) initLocked(useLME, useWD bool) error {
+	heci.useLME = useLME
+	heci.useWD = useWD
+	heci.useGUIDClient = false
+
+	// Close any previous device handle before reopening.
+	if err := heci.openMEIDevice(); err != nil {
 		return err
 	}
 
@@ -117,34 +157,34 @@ func (heci *Driver) initLocked(useLME, useWD bool) error {
 		data.data = MEI_IAMTHIF
 	}
 
-	// retry with backoff in case the device is busy after a reset
-	for i := 0; i < 5; i++ {
+	var err error
+
+	// retry with backoff in case the device is busy after a reset. The ME is
+	// typically ready within a few ms of a reopen and connect succeeds on the
+	// first retry, so start with a short backoff and ramp up only for the
+	// rarer cases where it stays busy longer. Don't sleep after the final
+	// attempt - there's no retry left to wait for.
+	for i := 0; i < heciConnectAttempts; i++ {
 		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
 		if err == nil {
 			break
 		}
 
-		if errors.Is(err, syscall.EBUSY) {
-			log.Warnf("mei connect busy, retry %d", i+1)
-			time.Sleep(time.Duration(i+1) * utils.HeciConnectRetryBackoff * time.Millisecond)
+		// Only a busy device is worth retrying; any other error won't clear by
+		// waiting. Don't sleep after the final attempt - there's no retry left.
+		if !errors.Is(err, syscall.EBUSY) || i == heciConnectAttempts-1 {
+			break
 		}
+
+		log.Warnf("mei connect busy, retry %d", i+1)
+		time.Sleep(time.Duration(i+1) * utils.HeciConnectRetryBackoff * time.Millisecond)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	t := MEIConnectClientData{}
-
-	err = binary.Read(bytes.NewBuffer(data.data[:]), binary.LittleEndian, &t)
-	if err != nil {
-		return err
-	}
-
-	heci.bufferSize = t.MaxMessageLength
-	heci.protocolVersion = t.ProtocolVersion // should be 4?
-
-	return nil
+	return heci.parseConnectClientData(data)
 }
 
 // InitWithGUID initializes the HECI driver with a specific GUID
@@ -156,8 +196,6 @@ func (heci *Driver) InitWithGUID(guid interface{}) error {
 	heci.useWD = false
 	heci.useGUIDClient = true
 
-	var err error
-
 	// Type assert to [16]uint8
 	guidBytes, ok := guid.([16]uint8)
 	if !ok {
@@ -165,28 +203,16 @@ func (heci *Driver) InitWithGUID(guid interface{}) error {
 	}
 
 	// Close any previous device handle before reopening.
-	if heci.meiDevice != nil {
-		_ = heci.meiDevice.Close()
-		heci.meiDevice = nil
-	}
-
-	heci.meiDevice, err = os.OpenFile(Device, syscall.O_RDWR, 0)
-	if err != nil {
-		if err.Error() == errMsgPermissionDenied {
-			log.Debug("need administrator privileges")
-		} else if err.Error() == errMsgNoSuchFile {
-			log.Error("MEI/driver is missing or the call to the HECI driver failed")
-		} else {
-			log.Error("Cannot open MEI Device")
-		}
-
+	if err := heci.openMEIDevice(); err != nil {
 		return err
 	}
 
 	data := CMEIConnectClientData{}
 	data.data = guidBytes
 
-	for i := 0; i < 3; i++ {
+	var err error
+
+	for i := 0; i < guidConnectAttempts; i++ {
 		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
 		if err == nil {
 			break
@@ -197,17 +223,7 @@ func (heci *Driver) InitWithGUID(guid interface{}) error {
 		return err
 	}
 
-	t := MEIConnectClientData{}
-
-	err = binary.Read(bytes.NewBuffer(data.data[:]), binary.LittleEndian, &t)
-	if err != nil {
-		return err
-	}
-
-	heci.bufferSize = t.MaxMessageLength
-	heci.protocolVersion = t.ProtocolVersion
-
-	return nil
+	return heci.parseConnectClientData(data)
 }
 
 // InitHOTHAM configures the HECI driver for the HOTHAM GUID interface.
@@ -219,31 +235,17 @@ func (heci *Driver) InitHOTHAM() error {
 	heci.useWD = false
 	heci.useGUIDClient = true
 
-	var err error
-
 	// Close any previous device handle before reopening.
-	if heci.meiDevice != nil {
-		_ = heci.meiDevice.Close()
-		heci.meiDevice = nil
-	}
-
-	heci.meiDevice, err = os.OpenFile(Device, syscall.O_RDWR, 0)
-	if err != nil {
-		if err.Error() == errMsgPermissionDenied {
-			log.Debug("need administrator privileges")
-		} else if err.Error() == errMsgNoSuchFile {
-			log.Error("AMT not found: MEI/driver is missing or the call to the HECI driver failed")
-		} else {
-			log.Errorf("Cannot open MEI Device: %v", err)
-		}
-
+	if err := heci.openMEIDevice(); err != nil {
 		return err
 	}
 
 	data := CMEIConnectClientData{}
 	data.data = MEI_HOTHAM
 
-	for i := 0; i < 3; i++ {
+	var err error
+
+	for i := 0; i < guidConnectAttempts; i++ {
 		err = Ioctl(heci.meiDevice.Fd(), IOCTL_MEI_CONNECT_CLIENT, uintptr(unsafe.Pointer(&data)))
 		if err == nil {
 			log.Tracef("InitHOTHAM: Connected successfully on attempt %d", i+1)
@@ -253,22 +255,16 @@ func (heci *Driver) InitHOTHAM() error {
 	}
 
 	if err != nil {
-		log.Errorf("InitHOTHAM: Failed to connect to HOTHAM GUID after 3 attempts: %v", err)
+		log.Errorf("InitHOTHAM: Failed to connect to HOTHAM GUID after %d attempts: %v", guidConnectAttempts, err)
 
 		return err
 	}
 
-	t := MEIConnectClientData{}
-
-	err = binary.Read(bytes.NewBuffer(data.data[:]), binary.LittleEndian, &t)
-	if err != nil {
+	if err := heci.parseConnectClientData(data); err != nil {
 		log.Errorf("InitHOTHAM: Failed to parse connection data: %v", err)
 
 		return err
 	}
-
-	heci.bufferSize = t.MaxMessageLength
-	heci.protocolVersion = t.ProtocolVersion
 
 	log.Tracef("InitHOTHAM: Connected to HOTHAM GUID: %s, Buffer size: %d, Protocol version: %d",
 		formatGUID(MEI_HOTHAM), heci.bufferSize, heci.protocolVersion)
@@ -299,8 +295,13 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 
 	if err != nil {
 		if errors.Is(err, syscall.ENODEV) || err.Error() == "no such device" {
-			log.Warn("mei device unavailable, reinitializing")
-
+			log.Warn("mei device unavailable, reinitializing, and retrying write")
+			// Brief settle to let the kernel finish tearing down the closed
+			// fd before reopen. initLocked retries MEI_CONNECT_CLIENT on EBUSY
+			// with its own ramped backoff, so this only needs to cover the
+			// teardown - not the full reinit delay that used to pad every
+			// post-keygen reinit by half a second.
+			time.Sleep(utils.HeciReopenSettleDelay * time.Millisecond)
 			// Use write lock during reinitialization.
 			heci.mu.Lock()
 
@@ -311,15 +312,11 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 
 			if heci.useGUIDClient {
 				heci.mu.Unlock()
-
 				return 0, ErrDeviceNotInitialized
 			}
 
-			time.Sleep(utils.HeciRetryDelay * time.Millisecond)
-
 			if initErr := heci.initLocked(heci.useLME, heci.useWD); initErr != nil {
 				heci.mu.Unlock()
-
 				return 0, initErr
 			}
 
@@ -459,13 +456,23 @@ func (heci *Driver) ReceiveMessage(buffer []byte, done *uint32) (bytesRead int, 
 
 			if initErr := heci.initLocked(heci.useLME, heci.useWD); initErr != nil {
 				heci.mu.Unlock()
-
 				return 0, initErr
 			}
 
 			deadline = time.Now().Add(utils.HeciReadTimeout * time.Second)
 
 			heci.mu.Unlock()
+
+			// In LME mode the firmware resets the APF session on reinit (it
+			// replays PROTOCOL_VERSION + tcpip-forwards), so any in-flight
+			// channel id is now stale. Surface that explicitly - mirroring the
+			// SendMessage ENODEV path - so the caller replays the handshake and
+			// re-opens the channel instead of silently waiting on a confirmation
+			// that will never arrive. LMS has no APF session, so it keeps
+			// transparently retrying.
+			if heci.useLME {
+				return 0, ErrDeviceReinitialized
+			}
 
 			continue
 		}

--- a/pkg/heci/linux.go
+++ b/pkg/heci/linux.go
@@ -323,6 +323,16 @@ func (heci *Driver) SendMessage(buffer []byte, done *uint32) (bytesWritten int, 
 				return 0, initErr
 			}
 
+			// In LME mode the firmware also resets the APF session on reinit
+			// (it replays PROTOCOL_VERSION + tcpip-forwards), so the caller's
+			// in-flight channel id is now stale. Surface that explicitly
+			// instead of silently replaying the original write.
+			if heci.useLME {
+				heci.mu.Unlock()
+
+				return 0, ErrDeviceReinitialized
+			}
+
 			fd = int(heci.meiDevice.Fd())
 			size, err = syscall.Write(fd, buffer)
 

--- a/pkg/heci/types.go
+++ b/pkg/heci/types.go
@@ -12,6 +12,11 @@ var (
 	ErrDeviceNotInitialized = errors.New("heci device not initialized")
 	// ErrReadTimeout indicates a HECI read operation exceeded its timeout.
 	ErrReadTimeout = errors.New("heci read timeout")
+	// ErrDeviceReinitialized indicates the HECI device was transparently
+	// reopened mid-operation (typically after ENODEV). Stateful callers (LME,
+	// which tracks per-session APF channel ids) must re-handshake and retry
+	// rather than reuse their pre-reinit state.
+	ErrDeviceReinitialized = errors.New("heci device reinitialized, retry required")
 )
 
 type Interface interface {

--- a/pkg/heci/types.go
+++ b/pkg/heci/types.go
@@ -5,7 +5,10 @@
 
 package heci
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	// ErrDeviceNotInitialized indicates the HECI device handle is unavailable.
@@ -18,6 +21,15 @@ var (
 	// rather than reuse their pre-reinit state.
 	ErrDeviceReinitialized = errors.New("heci device reinitialized, retry required")
 )
+
+// IsReadTimeout reports whether err is a HECI read timeout. It matches the
+// ErrReadTimeout sentinel via errors.Is and also accepts an error whose message
+// contains the sentinel text, so callers that only have a string-wrapped error
+// (e.g. one that crossed a boundary that lost the wrap chain) still classify it
+// as a benign read timeout.
+func IsReadTimeout(err error) bool {
+	return errors.Is(err, ErrReadTimeout) || (err != nil && strings.Contains(err.Error(), ErrReadTimeout.Error()))
+}
 
 type Interface interface {
 	Init(useLME, useWD bool) error

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -32,14 +32,34 @@ const (
 	MPSServerMaxLength = 256
 
 	// LMSConnectionTimeout is the maximum wait for LMS TCP connection setup.
-	LMSConnectionTimeout    = 10   // seconds
+	LMSConnectionTimeout    = 5    // seconds
 	LMSDialerTimeout        = 5    // seconds
-	HeciReadTimeout         = 30   // seconds
-	HeciRetryDelay          = 3000 // milliseconds
-	HeciReinitDelay         = 500  // milliseconds
-	HeciConnectRetryBackoff = 500  // milliseconds
+	HeciReadTimeout         = 3    // seconds
+	HeciRetryDelay          = 1500 // milliseconds
+	HeciReinitDelay         = 300  // milliseconds
+	HeciReopenSettleDelay   = 50   // milliseconds
+	HeciConnectRetryBackoff = 750  // milliseconds
 	WebSocketTimeout        = 60   // seconds
-	AMTResponseTimeout      = 30   // seconds
+	AMTResponseTimeout      = 4    // seconds
+
+	// LMEChannelOpenTimeout bounds the wait for APF_CHANNEL_OPEN_CONFIRMATION
+	// before a Listen goroutine that never signals Done() is abandoned. It is a
+	// safety net only: the happy path returns the moment the handshake WaitGroup
+	// drains, so this value never affects timing on a healthy session. Kept at
+	// the hardware-validated HeciReadTimeout + 15 (=18s) - do not lower it
+	// without on-hardware validation; it only ever costs latency on a wedged
+	// listener, never on the happy path.
+	LMEChannelOpenTimeout = HeciReadTimeout + 15 // seconds
+	// TLSTunnelResponseTimeout bounds how long the RPS loop waits for AMT's
+	// response to a forwarded message while the TLS tunnel is active; AMT can
+	// take 60+ seconds to restart its TLS subsystem after a port switch, so this
+	// is deliberately well above the non-tunnel AMTResponseTimeout.
+	TLSTunnelResponseTimeout = 90 // seconds
+	// LMEPortSwitchMaxRetries and LMEPortSwitchRetryDelay bound the LMS reconnect
+	// probe issued after an AMT TLS port switch (16992 -> 16993) while the AMT
+	// TLS subsystem is still settling on the new port.
+	LMEPortSwitchMaxRetries = 5
+	LMEPortSwitchRetryDelay = 5 // seconds
 
 	HelpHeader = "\nRemote Provisioning Client (RPC) - used for activation, deactivation, maintenance and status of AMT\n\n"
 


### PR DESCRIPTION


### LME enabled end to end.

[details of change ](https://github.com/device-management-toolkit/rpc-go/wiki/lme_changes-for-rpc%E2%80%90go-v3)

**Addreses:**
1. https://github.com/device-management-toolkit/rpc-go/issues/1208
2. https://github.com/device-management-toolkit/rpc-go/issues/1210
3. https://github.com/device-management-toolkit/rpc-go/issues/909

## Overall changes Done
<img width="2752" height="1536" alt="image" src="https://github.com/user-attachments/assets/30796ecc-3af5-479b-b2c3-7734379a0ab8" />

[](https://notebooklm.google.com/notebook/01872710-ef6f-40d9-8979-0c71fd561bfc/artifact/3f3c33ca-1de3-4ae7-a9cf-8dba551ed385?utm_source=nlm_web_share&utm_medium=google_oo&utm_campaign=art_share_2&utm_content=&utm_smc=nlm_web_share_google_oo_art_share_2_)

## Run results

#### Host Result Details
-------------------
 Summary |      |         | Local profile (S/Act/Deact) | Remote profile (S/Act/Deact)                                   
---------+------+---------+-----------------------------+------------------------------+-------------------
 Index   | Mode | AMT Ver | CCM                         | acm_p                        | ccm_p             
---------+------+---------+-----------------------------+------------------------------+-------------------
 1       | lme  | 16.1.27 | PASS / 12s / 1s             | PASS / 242s / 12s            | PASS / 186s / 12s 
 1       | lms  | 16.1.27 | PASS / 2s / 1s              | FAIL / 2s / 1s               | FAIL / 63s / 1s   
---------+------+---------+-----------------------------+------------------------------+-------------------
 2       | lme  | 18.1.18 | PASS / 2s / 2s              | PASS / 177s / 2s             | PASS / 140s / 3s  
 2       | lms  | 18.1.18 | PASS / 2s / 2s              | FAIL / 3s / 2s               | FAIL / 64s / 2s   
---------+------+---------+-----------------------------+------------------------------+-------------------
 3       | lme  | 19.0.11 | PASS / 7s / 2s              | PASS / 315s / 30s            | PASS / 236s / 29s 
 3       | lms  | 19.0.11 | PASS / 3s / 2s              | PASS / 271s / 13s            | PASS / 191s / 14s 
---------+------+---------+-----------------------------+------------------------------+-------------------
 4       | lme  | 21.0.2  | PASS / 5s / 2s              | PASS / 338s / 34s            | PASS / 252s / 33s 
 4       | lms  | 21.0.2  | PASS / 6s / 2s              | PASS / 293s / 17s            | PASS / 205s / 18s 