### PR TITLE
feat(rps): display real-time activation progress on the CLI

### DIFF
--- a/internal/rps/executor.go
+++ b/internal/rps/executor.go
@@ -5,11 +5,11 @@
 package rps
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -156,9 +156,14 @@ func (e *Executor) HandleDataFromRPS(dataFromServer []byte) bool {
 		return false
 	}
 
+	// Progress sentinel: keep the loop alive, forward nothing to LMS.
+	if string(msgPayload) == ProgressSentinel {
+		return false
+	}
+
 	// Detect port_switch sentinel from ProcessMessage
-	if strings.HasPrefix(string(msgPayload), PortSwitchSentinel) {
-		jsonData := string(msgPayload)[len(PortSwitchSentinel):]
+	if bytes.HasPrefix(msgPayload, []byte(PortSwitchSentinel)) {
+		jsonData := string(msgPayload[len(PortSwitchSentinel):])
 
 		err := e.handlePortSwitch(jsonData)
 		if err != nil {

--- a/internal/rps/message.go
+++ b/internal/rps/message.go
@@ -61,6 +61,8 @@ type MessagePayload struct {
 	FriendlyName      string                `json:"friendlyName,omitempty"`
 	TLSEnforced       bool                  `json:"tlsEnforced,omitempty"`
 	TLSTunnel         bool                  `json:"tlsTunnel,omitempty"`
+	// ProgressSupported tells RPS this client can handle `progress` messages.
+	ProgressSupported bool `json:"progressSupported,omitempty"`
 }
 
 // MethodTLSData is the method type for TLS tunnel data passthrough
@@ -77,6 +79,12 @@ const MethodPortSwitchAck = "port_switch_ack"
 
 // PortSwitchSentinel is the prefix used to detect port_switch payloads in HandleDataFromRPS
 const PortSwitchSentinel = "port_switch:"
+
+// MethodProgress is RPS reporting activation progress; informational only.
+const MethodProgress = "progress"
+
+// ProgressSentinel marks a progress message so the executor keeps the loop alive.
+const ProgressSentinel = "progress:"
 
 // PortSwitchPayload is the JSON payload from RPS's port_switch message
 type PortSwitchPayload struct {
@@ -226,6 +234,7 @@ func (p Payload) CreateMessageRequest(flags flags.Flags) (Message, error) {
 
 	payload.IPConfiguration = flags.IpConfiguration
 	payload.HostnameInfo = flags.HostnameInfo
+	payload.ProgressSupported = true
 
 	if flags.UUID != "" {
 		if isKnownInvalidUUID(flags.UUID) {

--- a/internal/rps/message_test.go
+++ b/internal/rps/message_test.go
@@ -267,6 +267,20 @@ func TestCreateMessageRequestNoUUID(t *testing.T) {
 	assert.Equal(t, expectedUUID, msgPayload.UUID)
 }
 
+func TestCreateMessageRequestProgressSupported(t *testing.T) {
+	result, createErr := p.CreateMessageRequest(flags.Flags{})
+	assert.NoError(t, createErr)
+	assert.NotEmpty(t, result.Payload)
+	decodedBytes, decodeErr := base64.StdEncoding.DecodeString(result.Payload)
+	assert.NoError(t, decodeErr)
+
+	msgPayload := MessagePayload{}
+	jsonErr := json.Unmarshal(decodedBytes, &msgPayload)
+	assert.NoError(t, jsonErr)
+	// The client advertises progress support so RPS streams progress messages.
+	assert.True(t, msgPayload.ProgressSupported)
+}
+
 func TestCreateMessageRequestHostnameInfo(t *testing.T) {
 	flags := flags.Flags{
 		HostnameInfo: flags.HostnameInfo{

--- a/internal/rps/rps.go
+++ b/internal/rps/rps.go
@@ -226,6 +226,14 @@ func (amt *AMTActivationServer) ProcessMessage(message []byte) []byte {
 		return []byte(PortSwitchSentinel + activation.Payload)
 	}
 
+	// Progress: log the message at info level, return a sentinel so the
+	// executor loop stays alive without forwarding to LMS.
+	if activation.Method == MethodProgress {
+		log.Info(activation.Message)
+
+		return []byte(ProgressSentinel)
+	}
+
 	statusMessage := StatusMessage{}
 
 	switch activation.Method {

--- a/internal/rps/rps_test.go
+++ b/internal/rps/rps_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/device-management-toolkit/rpc-go/v2/internal/flags"
 	"github.com/device-management-toolkit/rpc-go/v2/pkg/utils"
 	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -225,6 +227,51 @@ func TestProcessMessageSuccess(t *testing.T) {
 	server.Connect(true)
 	decodedMessage := server.ProcessMessage([]byte(activation))
 	assert.Nil(t, decodedMessage)
+}
+
+func TestProcessMessageProgress(t *testing.T) {
+	activation := `{
+        "method": "progress",
+        "message": "Configuring network settings"
+    }`
+	server := NewAMTActivationServer(testFlags)
+	server.Connect(true)
+
+	// Hook after Connect so only ProcessMessage's output is captured.
+	logHook := test.NewGlobal()
+	defer logHook.Reset()
+
+	decodedMessage := server.ProcessMessage([]byte(activation))
+	// Sentinel (never nil) keeps the executor loop alive.
+	assert.Equal(t, ProgressSentinel, string(decodedMessage))
+	// Progress is logged at info level so it shows without -v.
+	entry := logHook.LastEntry()
+	assert.NotNil(t, entry)
+	assert.Equal(t, logrus.InfoLevel, entry.Level)
+	assert.Equal(t, "Configuring network settings", entry.Message)
+}
+
+func TestProcessMessageProgressJSONOutputLogged(t *testing.T) {
+	activation := `{
+        "method": "progress",
+        "message": "Configuring network settings"
+    }`
+	jsonFlags := flags.NewFlags([]string{}, MockPRSuccess)
+	jsonFlags.JsonOutput = true
+	server := NewAMTActivationServer(jsonFlags)
+	server.Connect(true)
+
+	// Hook after Connect so only ProcessMessage's output is captured.
+	logHook := test.NewGlobal()
+	defer logHook.Reset()
+
+	decodedMessage := server.ProcessMessage([]byte(activation))
+	// Sentinel still returned in --json mode.
+	assert.Equal(t, ProgressSentinel, string(decodedMessage))
+	// Progress is logged in --json mode too (no special suppression).
+	entry := logHook.LastEntry()
+	assert.NotNil(t, entry)
+	assert.Equal(t, "Configuring network settings", entry.Message)
 }
 
 func TestProcessMessageUnformattedSuccess(t *testing.T) {


### PR DESCRIPTION
Handle the new `progress` message from RPS so operators can see what provisioning step is currently running during the ~3-minute activation window. Progress lines are logged at info level so they are visible without -v.

The handler returns a sentinel (never nil) so the executor loop stays alive and nothing is forwarded to LMS, mirroring the existing port_switch/heartbeat handling.

Advertise `progressSupported` in the initial activation payload so RPS only streams progress to clients that understand it — older RPS ignores the additive field and mixed-version deployments stay safe.

Refs device-management-toolkit/rps#2665