### PR TITLE
build(deps): bump golang.org/x/crypto to 0.53.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPc
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Why golang.org/x/crypto must be bumped to v0.53.0

The BDBA scan flagged 6 CVEs whose fixes land in golang.org/x/net v0.55.0. However, in this module x/net is not imported directly — it is pulled in transitively through golang.org/x/crypto. Go's Minimum Version Selection (MVS) therefore uses the x/net version required by whichever x/crypto version is in the graph as the effective floor.

6 CVEs were identified in the latest scan:
[CVE-2026-39821](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-39821)
[CVE-2026-25680](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-25680)
[CVE-2026-25681](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-25681)
[CVE-2026-27136](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-27136)
[CVE-2026-42502](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-42502)
[CVE-2026-42506](https://bdba001.icloud.intel.com/#/vulnerabilities/CVE-2026-42506)

The dependency chain is:

x/crypto version	Required x/net (minimum)
v0.52.0 (old)	         v0.54.0 (vulnerable)
v0.53.0 (new)	         v0.55.0 (CVE fix)

With x/crypto v0.52.0, the graph pins x/net at v0.54.0, which still contains the vulnerable code. Bumping x/crypto to v0.53.0 raises the x/net floor to v0.55.0, which includes the CVE fixes. This is why the x/crypto bump is required — it is the mechanism that pulls the transitive x/net dependency up to a patched version.