### PR TITLE
build(docker): bump golang builder to 1.26.5 to clear Trivy CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # **********************************************************************
 
-FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 
 RUN apk update && apk upgrade && apk add --no-cache git
 


### PR DESCRIPTION
## Problem

The **Trivy Container Scan** workflow fails on PRs. It builds the image and fails on any fixable vulnerability (`exit-code: 1`, all severities `UNKNOWN..CRITICAL`, `ignore-unfixed: true`). The final image is `FROM scratch`, so the only scannable content is the compiled Go binary.

The pinned `golang:1.26-alpine` builder (digest `f23e8b22...`) is **Go 1.26.2**, which stamps the binary with a stdlib version flagged for **13 CVEs** across `crypto/x509`, `net`, `net/http2`, `net/mail`, `mime`, and `html/template` (7 HIGH / 4 MEDIUM / 2 UNKNOWN). This is independent of any source change — the scan started failing as new CVEs were published against the stale toolchain.

## Fix

Bump the pinned builder digest to **Go 1.26.5** (current `1.26-alpine` == `1.26.5-alpine`), which carries fixes for all reported CVEs. No `go.mod` change needed: it declares `go 1.25.0` with no `toolchain` directive, so the builder image's toolchain determines the embedded stdlib version.

## Verification

Rebuilt the binary with the Go 1.26.5 toolchain and reran Trivy with the exact CI flags (`--ignore-unfixed --severity UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --exit-code 1`):

- Before (1.26.2): **13** vulnerabilities -> scan fails
- After (1.26.5): **0** vulnerabilities, exit 0 -> scan passes