### PR TITLE
build(deps): bump github/codeql-action init and analyze to v4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
 
@@ -57,7 +57,7 @@ jobs:
         make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
     - name: Generate Security Report
       uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
       continue-on-error: true


### PR DESCRIPTION
Combines the two separate Dependabot bumps for `github/codeql-action` into a single PR, and pins both sub-actions to the **same** release SHA.

## Why combine

Dependabot opened two PRs against the same file, each moving a different line and — because they were cut at different times — to **different versions**:

| PR | Sub-action | Target |
|----|-----------|--------|
| #1420 | `init` | v4.37.0 (`99df26d4`) |
| #1421 | `analyze` | v4.36.3 (`54f647b7`) |

`init` and `analyze` are sub-paths of the same `github/codeql-action` release and should always pin to one commit. Merging the PRs independently would leave them on mismatched versions.

## This PR

Pins **both** `init` and `analyze` to `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` = **v4.37.0** (the latest release, verified via the annotated tag), which supersedes the v4.36.3 bump in #1421.

Also corrects the version comment: the previous SHA `8aad20d1` is actually **v4.36.2**, not `v3.29.5` as the stale comment claimed.

Supersedes #1420 and #1421 — both can be closed once this merges.