### PR TITLE
fix(lme): add to WaitGroup before sending CHANNEL_OPEN

### DIFF
--- a/internal/lm/engine.go
+++ b/internal/lm/engine.go
@@ -289,8 +289,20 @@ func (lme *LMEConnection) Connect() error {
 
 		bin_buf := apf.ChannelOpenPort(lme.ourChannel, port)
 
+		// Account for this CHANNEL_OPEN before Send so a concurrent APF listener
+		// can't process OPEN_CONFIRMATION/OPEN_FAILURE and call Done() first.
+		// This ordering prevents WaitGroup underflow across retry attempts.
+		if lme.Session.WaitGroup != nil {
+			lme.Session.WaitGroup.Add(1)
+		}
+
 		err := lme.Command.Send(bin_buf.Bytes())
 		if err != nil {
+			// Undo the Add(1) since we failed to send the channel open
+			if lme.Session.WaitGroup != nil {
+				lme.Session.WaitGroup.Done()
+			}
+
 			lastErr = err
 			if attempts < 4 && (errors.Is(err, heci.ErrDeviceReinitialized) || err.Error() == "no such device" || err.Error() == "The device is not connected.") {
 				log.Warn(err.Error())
@@ -333,7 +345,6 @@ func (lme *LMEConnection) Connect() error {
 		}
 
 		lme.retries = 0
-		lme.Session.WaitGroup.Add(1)
 
 		return nil
 	}

--- a/internal/lm/engine_test.go
+++ b/internal/lm/engine_test.go
@@ -54,6 +54,10 @@ func (c *MockHECICommands) ReceiveMessage(buffer []byte, done *uint32) (bytesRea
 // payload length back so pthi.Command.Send doesn't see a byteswritten mismatch.
 type queuedHECIMock struct {
 	queue chan []byte
+	// onSend, when set, runs synchronously inside SendMessage. Connect uses
+	// pthi.Command.Send, which calls this directly, so tests can observe or
+	// interleave logic at the exact moment a frame is sent.
+	onSend func()
 }
 
 func newQueuedHECIMock(buffer int) *queuedHECIMock {
@@ -65,6 +69,10 @@ func (m *queuedHECIMock) InitHOTHAM() error                   { return nil }
 func (m *queuedHECIMock) InitWithGUID(guid interface{}) error { return nil }
 func (m *queuedHECIMock) GetBufferSize() uint32               { return 5120 }
 func (m *queuedHECIMock) SendMessage(buffer []byte, done *uint32) (int, error) {
+	if m.onSend != nil {
+		m.onSend()
+	}
+
 	return len(buffer), nil
 }
 
@@ -403,4 +411,39 @@ func Test_Listen_StaleCloseIgnoredUntilOpenFailure(t *testing.T) {
 	}
 
 	close(mock.queue)
+}
+
+// Test_Connect_WaitGroupManagement covers the #1398 ordering regression by
+// triggering Done() during Send; Add must already be in place.
+func Test_Connect_WaitGroupManagement(t *testing.T) {
+	resetMock()
+
+	lmDataChannel := make(chan []byte, 1)
+	lmErrorChannel := make(chan error, 1)
+	wg := &sync.WaitGroup{}
+	lme := NewLMEConnection(lmDataChannel, lmErrorChannel, wg)
+
+	mock := newQueuedHECIMock(1)
+	mock.onSend = func() {
+		lme.Session.WaitGroup.Done()
+	}
+	lme.Command.Heci = mock
+
+	assert.NotPanics(t, func() {
+		err := lme.Connect()
+		assert.NoError(t, err)
+	})
+
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("WaitGroup counter not balanced after Connect")
+	}
 }


### PR DESCRIPTION
Fix a race in LMEConnection.Connect where the Session.WaitGroup.Add(1) for a pending CHANNEL_OPEN was performed after Command.Send. On fast paths the APF processor could receive OPEN_CONFIRMATION/OPEN_FAILURE and call Done() before the corresponding Add, causing a sync: negative WaitGroup counter panic (worst) or an unbalanced counter across retry attempts (best).

Change

In internal/lm/engine.go: move WaitGroup.Add(1) to run before Command.Send(bin_buf.Bytes()). If Send fails, undo with Done() so the counter stays balanced. Removed the trailing Add(1) that ran after handshake success.
In internal/lm/engine_test.go: add Test_Connect_WaitGroupManagement which uses a queuedHECIMock.onSend hook to invoke Done() synchronously during Send, reproducing the ordering hazard. Test asserts no panic and that wg.Wait() returns within 100 ms.
Impact

Prevents WaitGroup underflow / deadlock during LME channel setup, especially under retry loops. No behavior change on the success path.

_fix_ https://github.com/device-management-toolkit/rpc-go/issues/1398