### PR TITLE
feat: add discovery timestamps to deviceInfo

### DIFF
--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -448,10 +448,11 @@ type syncDeviceInfo struct {
 	FWBuild              string        `json:"fwBuild"`
 	FWSku                string        `json:"fwSku"`
 	Discovered           *bool         `json:"discovered,omitempty"`
+	FirstDiscovered      *time.Time    `json:"firstDiscovered,omitempty"`
 	CurrentMode          string        `json:"currentMode"`
 	Features             string        `json:"features"`
 	IPAddress            string        `json:"ipAddress"`
-	LastUpdated          time.Time     `json:"lastUpdated"`
+	LastSynced           *time.Time    `json:"lastSynced,omitempty"`
 	TLSMode              string        `json:"tlsMode,omitempty"`
 	UPID                 *syncUPIDInfo `json:"upid,omitempty"`
 	AMTEnabledInBIOS     *bool         `json:"amtEnabledInBIOS,omitempty"`
@@ -512,10 +513,16 @@ func (s *InfoService) SyncDeviceInfo(ctx *Context, result *InfoResult, urlArg st
 			CurrentMode:  result.ControlMode,
 			Features:     result.Features,
 			IPAddress:    bestIPAddress(result),
-			LastUpdated:  time.Now(),
 			LMSInstalled: utils.DetectLMS(s.localTLSEnforced),
 		},
 	}
+
+	// lastSynced advances on every sync (discovered true or false). Because this
+	// is the only sync entry point, non-sync operations (AMT password, tags, etc.)
+	// never touch it. The same timestamp is reused for the 404 create below so the
+	// created record and the retried PATCH agree.
+	now := time.Now().UTC()
+	payload.DeviceInfo.LastSynced = &now
 
 	// Populate additional discovery fields
 	s.populateDiscoveryFields(&payload.DeviceInfo, result)
@@ -556,7 +563,7 @@ func (s *InfoService) SyncDeviceInfo(ctx *Context, result *InfoResult, urlArg st
 			discovered = &autoDiscovered
 		}
 
-		if err := s.createDevice(httpClient, endpoint, result, authToken, discovered); err != nil {
+		if err := s.createDevice(httpClient, endpoint, result, authToken, discovered, now); err != nil {
 			log.Debugf("device registration (POST) failed: %v", err)
 
 			return fmt.Errorf("device not found; failed to auto-register device: %w", err)
@@ -685,8 +692,9 @@ func (s *InfoService) doPatchRequest(client *http.Client, endpoint string, body 
 
 // createDevice sends a minimal POST to register the device before retrying PATCH sync.
 // The discovered parameter indicates if this is an auto-discovered device (true) or explicitly provisioned (false).
-func (s *InfoService) createDevice(client *http.Client, endpoint string, result *InfoResult, authToken string, discovered *bool) error {
-	body, hostname, err := s.buildDeviceCreatePayload(result, discovered)
+// syncedAt is the sync timestamp, reused so the created record matches the retried PATCH.
+func (s *InfoService) createDevice(client *http.Client, endpoint string, result *InfoResult, authToken string, discovered *bool, syncedAt time.Time) error {
+	body, hostname, err := s.buildDeviceCreatePayload(result, discovered, syncedAt)
 	if err != nil {
 		return err
 	}
@@ -705,11 +713,14 @@ func (s *InfoService) createDevice(client *http.Client, endpoint string, result 
 }
 
 // buildDeviceCreatePayload constructs the minimal JSON payload for device registration.
-func (s *InfoService) buildDeviceCreatePayload(result *InfoResult, discovered *bool) ([]byte, string, error) {
+// syncedAt stamps firstDiscovered and lastSynced so the new record agrees with the retried PATCH.
+func (s *InfoService) buildDeviceCreatePayload(result *InfoResult, discovered *bool, syncedAt time.Time) ([]byte, string, error) {
 	hostname := s.getCreateHostname(result)
 
 	type deviceInfoCreate struct {
-		Discovered *bool `json:"discovered,omitempty"`
+		Discovered      *bool      `json:"discovered,omitempty"`
+		FirstDiscovered *time.Time `json:"firstDiscovered,omitempty"`
+		LastSynced      *time.Time `json:"lastSynced,omitempty"`
 	}
 
 	createPayload := struct {
@@ -722,7 +733,15 @@ func (s *InfoService) buildDeviceCreatePayload(result *InfoResult, discovered *b
 	}
 
 	if discovered != nil {
-		createPayload.DeviceInfo = &deviceInfoCreate{Discovered: discovered}
+		// lastSynced advances on every sync; firstDiscovered is only stamped for a
+		// genuine discovery (discovered=true) and is immutable thereafter.
+		createPayload.DeviceInfo = &deviceInfoCreate{
+			Discovered: discovered,
+			LastSynced: &syncedAt,
+		}
+		if *discovered {
+			createPayload.DeviceInfo.FirstDiscovered = &syncedAt
+		}
 	}
 
 	body, err := json.Marshal(createPayload)

--- a/internal/commands/amtinfo_test.go
+++ b/internal/commands/amtinfo_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/managementpresence"
 	ipshttp "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/http"
@@ -490,6 +491,100 @@ func TestInfoService_SyncDeviceInfo_404_PostFallback_ExplicitlyProvisioned(t *te
 	require.True(t, ok, "deviceInfo should be present in POST body")
 	assert.NotNil(t, deviceInfo["discovered"], "discovered should be in POST deviceInfo")
 	assert.False(t, deviceInfo["discovered"].(bool), "discovered should be false for explicitly provisioned devices")
+}
+
+// TestInfoService_SyncDeviceInfo_Timestamps covers the discovery timestamp behavior
+// across every sync scenario: existing device (single PATCH) and 404 auto-register
+// (POST + retry PATCH), for both discovered=true and discovered=false. Invariants:
+//   - lastSynced is stamped on every sync, regardless of discovered.
+//   - firstDiscovered and discovered are only sent on POST creation, never on PATCH.
+//   - firstDiscovered is only stamped when discovered=true, and equals the created lastSynced.
+//   - The POST and the retried PATCH carry the same lastSynced timestamp.
+func TestInfoService_SyncDeviceInfo_Timestamps(t *testing.T) {
+	const uuid = "12345678-1234-1234-1234-123456789ABC"
+
+	tests := []struct {
+		name         string
+		discovered   bool
+		deviceExists bool // false → first PATCH 404s, triggering POST create + retry PATCH
+	}{
+		{"existing device, discovered", true, true},
+		{"existing device, provisioned", false, true},
+		{"404 auto-register, discovered", true, false},
+		{"404 auto-register, provisioned", false, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewInfoService(nil)
+			ctx := &Context{SkipCertCheck: true}
+			result := &InfoResult{UUID: uuid}
+
+			var (
+				patchCount int
+				patchBody  syncPayload            // the last successful PATCH
+				postBody   map[string]interface{} // set only when a POST create happens
+			)
+
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+
+				switch r.Method {
+				case http.MethodPatch:
+					patchCount++
+					if !tt.deviceExists && patchCount == 1 {
+						w.WriteHeader(http.StatusNotFound)
+
+						return
+					}
+
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&patchBody))
+					w.WriteHeader(http.StatusOK)
+				case http.MethodPost:
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&postBody))
+					w.WriteHeader(http.StatusCreated)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			err := service.SyncDeviceInfo(ctx, result, server.URL+"/api/v1/devices", nil, &tt.discovered)
+			require.NoError(t, err)
+
+			// PATCH invariants (apply to every scenario).
+			require.NotNil(t, patchBody.DeviceInfo.LastSynced, "lastSynced should be sent on every sync")
+			assert.Nil(t, patchBody.DeviceInfo.FirstDiscovered, "firstDiscovered should never be in PATCH")
+			assert.Nil(t, patchBody.DeviceInfo.Discovered, "discovered should never be in PATCH")
+
+			if tt.deviceExists {
+				assert.Equal(t, 1, patchCount, "existing device needs a single PATCH")
+
+				return
+			}
+
+			// 404 auto-register: verify POST create body and timestamp agreement.
+			assert.Equal(t, 2, patchCount, "404 should trigger create then retry PATCH")
+
+			deviceInfo, ok := postBody["deviceInfo"].(map[string]interface{})
+			require.True(t, ok, "deviceInfo should be present in POST body")
+			assert.Equal(t, tt.discovered, deviceInfo["discovered"], "discovered should reflect the sync source")
+
+			lastSyncedPost, _ := deviceInfo["lastSynced"].(string)
+			require.NotEmpty(t, lastSyncedPost, "lastSynced should be set on creation")
+			assert.Equal(t, lastSyncedPost, patchBody.DeviceInfo.LastSynced.Format(time.RFC3339Nano),
+				"POST and retried PATCH should carry the same lastSynced")
+
+			firstDiscovered, _ := deviceInfo["firstDiscovered"].(string)
+			if tt.discovered {
+				assert.Equal(t, lastSyncedPost, firstDiscovered, "firstDiscovered should match lastSynced on discovery")
+			} else {
+				assert.Empty(t, firstDiscovered, "firstDiscovered should be absent for provisioned devices")
+			}
+		})
+	}
 }
 
 func TestNewInfoService(t *testing.T) {

--- a/internal/device/api.go
+++ b/internal/device/api.go
@@ -166,30 +166,31 @@ type TLSSettingsUpdate struct {
 
 // DeviceInfo carries device metadata sent to the console.
 type DeviceInfo struct {
-	FWVersion            string    `json:"fwVersion,omitempty"`
-	FWBuild              string    `json:"fwBuild,omitempty"`
-	FWSku                string    `json:"fwSku,omitempty"`
-	Discovered           *bool     `json:"discovered,omitempty"`
-	CurrentMode          string    `json:"currentMode,omitempty"`
-	Features             string    `json:"features,omitempty"`
-	IPAddress            string    `json:"ipAddress,omitempty"`
-	LastUpdated          time.Time `json:"lastUpdated,omitempty"`
-	TLSMode              string    `json:"tlsMode,omitempty"`
-	UPID                 *UPIDInfo `json:"upid,omitempty"`
-	AMTEnabledInBIOS     *bool     `json:"amtEnabledInBIOS,omitempty"`
-	MEInterfaceVersion   string    `json:"meInterfaceVersion,omitempty"`
-	DHCPEnabled          *bool     `json:"dhcpEnabled,omitempty"`
-	CertHashes           []string  `json:"certHashes,omitempty"`
-	LMSInstalled         *bool     `json:"lmsInstalled,omitempty"`
-	LMSVersion           string    `json:"lmsVersion,omitempty"`
-	OSName               string    `json:"osName,omitempty"`
-	OSVersion            string    `json:"osVersion,omitempty"`
-	OSDistro             string    `json:"osDistro,omitempty"`
-	CPUModel             string    `json:"cpuModel,omitempty"`
-	OSIPAddress          string    `json:"osIpAddress,omitempty"`
-	EthernetAdapterCount int       `json:"ethernetAdapterCount,omitempty"`
-	MonitorConnected     *bool     `json:"monitorConnected,omitempty"`
-	IEEE8021xEnabled     *bool     `json:"ieee8021xEnabled,omitempty"`
+	FWVersion            string     `json:"fwVersion,omitempty"`
+	FWBuild              string     `json:"fwBuild,omitempty"`
+	FWSku                string     `json:"fwSku,omitempty"`
+	Discovered           *bool      `json:"discovered,omitempty"`
+	FirstDiscovered      *time.Time `json:"firstDiscovered,omitempty"`
+	CurrentMode          string     `json:"currentMode,omitempty"`
+	Features             string     `json:"features,omitempty"`
+	IPAddress            string     `json:"ipAddress,omitempty"`
+	LastSynced           *time.Time `json:"lastSynced,omitempty"`
+	TLSMode              string     `json:"tlsMode,omitempty"`
+	UPID                 *UPIDInfo  `json:"upid,omitempty"`
+	AMTEnabledInBIOS     *bool      `json:"amtEnabledInBIOS,omitempty"`
+	MEInterfaceVersion   string     `json:"meInterfaceVersion,omitempty"`
+	DHCPEnabled          *bool      `json:"dhcpEnabled,omitempty"`
+	CertHashes           []string   `json:"certHashes,omitempty"`
+	LMSInstalled         *bool      `json:"lmsInstalled,omitempty"`
+	LMSVersion           string     `json:"lmsVersion,omitempty"`
+	OSName               string     `json:"osName,omitempty"`
+	OSVersion            string     `json:"osVersion,omitempty"`
+	OSDistro             string     `json:"osDistro,omitempty"`
+	CPUModel             string     `json:"cpuModel,omitempty"`
+	OSIPAddress          string     `json:"osIpAddress,omitempty"`
+	EthernetAdapterCount int        `json:"ethernetAdapterCount,omitempty"`
+	MonitorConnected     *bool      `json:"monitorConnected,omitempty"`
+	IEEE8021xEnabled     *bool      `json:"ieee8021xEnabled,omitempty"`
 }
 
 // UPIDInfo carries UPID details for the console.


### PR DESCRIPTION
Add firstDiscovered (immutable) and rename lastUpdated to lastSynced.

Related to #1394

Depends on https://github.com/device-management-toolkit/console/pull/1136

Description:

| Field | When set | Mutable? |
|-----|---------|-----------|
| firstDiscovered | first discovery (discovered=true only) | no (write-once) |
| discovered | device creation | no (write-once) |
| lastSynced | every sync | yes (advances) |

Note: lastUpdated is renamed to lastSynced; console maps the legacy lastUpdated on read so existing console keep working.

Observe the fields from the output:
discovered, firstDiscovered and lastSynced

Query from host
```
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize -H "Content-Type: application/json" -d '{"username":"<username>","password":"<password>"}' | jq -r '.token') && curl -sk https://localhost:8181/api/v1/devices -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
```

Sync before activation:
discovered=true; firstDiscovered and lastSynced are equal:

```
sudo ./rpc amtinfo --sync --url https://<host_ip_addr>:8181/api/v1/devices \
  --auth-endpoint https://<host_ip_addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```

Example:
```
"deviceInfo": {
  "discovered": true,
  "firstDiscovered": "2026-07-14T07:23:12Z",
  "lastSynced": "2026-07-14T07:23:12Z"
}
```

Activate directly:
discovered=false; firstDiscovered omitted; lastSynced set.
Use any one of below command:

```
sudo ./rpc activate --local --profile profile.yaml \
--key "<profile_key>" \
--skip-amt-cert-check --skip-cert-check \
--auth-endpoint "https://<host_ip_addr>:8181/api/v1/authorize" \
--auth-username <username> --auth-password "<password>" -v --log-level=debug
```

or

```
sudo ./rpc activate --url "https://<console-host>/api/v1/admin/profiles/export/<profile-name>?domainName=<domain-name>" --auth-username <username> --auth-password <password> --skip-amt-cert-check --skip-cert-check -v --log-level=debug
```

or

```
sudo ./rpc activate --profile <path-to-profile-file> --key <32-byte-key> --auth-endpoint https://<console-host>/api/v1/authorize --auth-username <username> --auth-password <password> --skip-amt-cert-check --log-level=debug -v --skip-cert-check
```

On later syncs: discovered and firstDiscovered stay unchanged (immutable); only lastSynced advances.
Full deactivation deletes the console record, so a later sync/activate creates a new record - firstDiscovered and discovered are set fresh:

```
sudo ./rpc deactivate --local --skip-amt-cert-check --skip-cert-check \
  --auth-endpoint "https://<host_ip_addr>:8181/api/v1/authorize" \
  --auth-username "<username>" \
  --auth-password "<password>" -v --log-level=debug
```