### PR TITLE
refactor(internal): remove unused cert chain helpers

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -11,18 +11,15 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"net"
 	"strings"
 	"time"
 
 	"github.com/device-management-toolkit/rpc-go/v2/internal/interfaces"
 	log "github.com/sirupsen/logrus"
-	"software.sslmate.com/src/go-pkcs12"
 )
 
 // IEEE8021xCertHandles holds certificate and key handles for IEEE 802.1x configuration
@@ -38,15 +35,6 @@ type Composite struct {
 	Pem         string
 	Fingerprint string
 	privateKey  *rsa.PrivateKey
-}
-
-type CompositeChain struct {
-	Root         Composite
-	Intermediate Composite
-	Leaf         Composite
-	PfxData      []byte
-	Pfxb64       string
-	PfxPassword  string
 }
 
 const remoteProvisioningClientOU = "Remote Provisioning Client"
@@ -98,52 +86,6 @@ func GetRootCATemplate() x509.Certificate {
 		NotBefore:    time.Now().AddDate(-1, 0, 0),
 		NotAfter:     time.Now().AddDate(20, 0, 0),
 		IsCA:         true,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-		},
-		KeyUsage: x509.KeyUsageDigitalSignature |
-			x509.KeyUsageCertSign |
-			x509.KeyUsageKeyEncipherment |
-			x509.KeyUsageDataEncipherment,
-		BasicConstraintsValid: true,
-	}
-}
-
-func GetIntermediateCATemplate() x509.Certificate {
-	return x509.Certificate{
-		SerialNumber: big.NewInt(1500),
-		Subject: pkix.Name{
-			Organization:       []string{"Intel"},
-			OrganizationalUnit: []string{remoteProvisioningClientOU},
-			CommonName:         "RPC Intermediate CA Certificate",
-			Country:            []string{"US"},
-		},
-		NotBefore: time.Now().AddDate(-1, 0, 0),
-		NotAfter:  time.Now().AddDate(20, 0, 0),
-		IsCA:      true,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-		},
-		KeyUsage: x509.KeyUsageDigitalSignature |
-			x509.KeyUsageCertSign |
-			x509.KeyUsageKeyEncipherment |
-			x509.KeyUsageDataEncipherment,
-		BasicConstraintsValid: true,
-	}
-}
-
-func GetLeafTemplate() x509.Certificate {
-	return x509.Certificate{
-		SerialNumber: big.NewInt(1500),
-		Subject: pkix.Name{
-			Organization:       []string{"Intel"},
-			OrganizationalUnit: []string{remoteProvisioningClientOU},
-			CommonName:         "RPC Leaf Certificate",
-			Country:            []string{"US"},
-		},
-		NotBefore:   time.Now().AddDate(-1, 0, 0),
-		NotAfter:    time.Now().AddDate(20, 0, 0),
-		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageServerAuth,
 		},
@@ -228,60 +170,6 @@ func ParseAMTPublicKey(derKey string) (any, error) {
 	}
 
 	return pubKey, err
-}
-
-func NewCompositeChain(password string) (CompositeChain, error) {
-	chain := CompositeChain{}
-	chain.Root, _ = NewRootComposite()
-
-	chain.Intermediate = Composite{}
-	template := GetIntermediateCATemplate()
-
-	var err error
-
-	chain.Intermediate.privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		log.Error(err)
-
-		return chain, err
-	}
-
-	err = chain.Intermediate.GenerateCert(&template, chain.Root.Cert, &chain.Intermediate.privateKey.PublicKey, chain.Root.privateKey)
-	if err != nil {
-		log.Error(err)
-
-		return chain, err
-	}
-
-	chain.Leaf = Composite{}
-	template = GetLeafTemplate()
-
-	chain.Leaf.privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		log.Error(err)
-
-		return chain, err
-	}
-
-	err = chain.Leaf.GenerateCert(&template, chain.Intermediate.Cert, &chain.Leaf.privateKey.PublicKey, chain.Intermediate.privateKey)
-	if err != nil {
-		log.Error(err)
-
-		return chain, err
-	}
-
-	chain.PfxPassword = password
-	chain.PfxData, err = pkcs12.Legacy.Encode(
-		chain.Leaf.privateKey,
-		chain.Leaf.Cert,
-		[]*x509.Certificate{
-			chain.Intermediate.Cert,
-			chain.Root.Cert,
-		},
-		chain.PfxPassword)
-	chain.Pfxb64 = base64.StdEncoding.EncodeToString(chain.PfxData)
-
-	return chain, err
 }
 
 // ConfigureIEEE8021xCertificates handles adding certificates for IEEE 802.1x configuration

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -6,7 +6,6 @@
 package certs
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,20 +45,11 @@ func TestNewSignedCompositeAMT16(t *testing.T) {
 
 	RunNewSignedCompositeTest(t, amt16DER)
 }
-
-func TestNewCompositeChain(t *testing.T) {
-	chain, err := NewCompositeChain("test")
-	assert.Nil(t, err)
-	assert.NotEmpty(t, chain.Root.Pem)
-	assert.NotEmpty(t, chain.Root.Fingerprint)
-	assert.NotEmpty(t, chain.Intermediate.Pem)
-	assert.NotEmpty(t, chain.Intermediate.Fingerprint)
-	assert.NotEmpty(t, chain.Leaf.Pem)
-	assert.NotEmpty(t, chain.Leaf.Fingerprint)
-
-	assert.True(t, strings.Contains(chain.Root.Pem, "BEGIN CERTIFICATE"))
-	assert.True(t, strings.Contains(chain.Root.Pem, "END CERTIFICATE"))
-	strippedPem := chain.Root.StripPem()
-	assert.False(t, strings.Contains(strippedPem, "BEGIN CERTIFICATE"))
-	assert.False(t, strings.Contains(strippedPem, "END CERTIFICATE"))
+func TestStripPem(t *testing.T) {
+	c := Composite{Pem: "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n"}
+	stripped := c.StripPem()
+	assert.Equal(t, "ABC", stripped)
+	assert.NotContains(t, stripped, "BEGIN CERTIFICATE")
+	assert.NotContains(t, stripped, "END CERTIFICATE")
+	assert.NotContains(t, stripped, "\n")
 }


### PR DESCRIPTION
Removed the unused function NewCompositeChain() and its related helper functions.