### PR TITLE
feat(cli): add --discover and --register as aliases for amtinfo --sync

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -100,6 +100,40 @@ func TestParse_WSManCommandAliases(t *testing.T) {
 	}
 }
 
+func TestParse_AmtInfoSyncAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"--sync", []string{"rpc", "amtinfo", "--sync", "--url", "https://example.com/api/v1/devices"}},
+		{"--discover", []string{"rpc", "amtinfo", "--discover", "--url", "https://example.com/api/v1/devices"}},
+		{"--register", []string{"rpc", "amtinfo", "--register", "--url", "https://example.com/api/v1/devices"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockAMT := mock.NewMockInterface(ctrl)
+			mockAMT.EXPECT().GetChangeEnabled().Return(amt.ChangeEnabledResponse(0), nil).AnyTimes()
+			mockAMT.EXPECT().GetControlMode().Return(1, nil).AnyTimes()
+			mockAMT.EXPECT().Close().Return(nil).AnyTimes()
+
+			_, parsed, err := Parse(tt.args, mockAMT)
+			assert.NoError(t, err)
+
+			if !assert.NotNil(t, parsed) {
+				return
+			}
+
+			assert.True(t, parsed.AmtInfo.Sync, "Sync should be true when %s is passed", tt.name)
+		})
+	}
+}
+
 func TestGlobalsBeforeApply(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/commands/amtinfo.go
+++ b/internal/commands/amtinfo.go
@@ -215,7 +215,7 @@ type AmtInfoCmd struct {
 	All bool `help:"Show All AMT Information" short:"A"`
 
 	// Sync to server flags
-	Sync bool   `help:"Sync device info to remote server via HTTP PATCH"`
+	Sync bool   `help:"Sync device info to remote server via HTTP PATCH (aliases: --discover, --register)" aliases:"discover,register"`
 	URL  string `help:"Endpoint URL of the devices API (e.g., https://mps.example.com/api/v1/devices)" name:"url"`
 }
 
@@ -240,7 +240,7 @@ func (cmd *AmtInfoCmd) Validate(kctx *kong.Context) error {
 	// Basic validation for sync mode
 	if cmd.Sync {
 		if strings.TrimSpace(cmd.URL) == "" {
-			return fmt.Errorf("--url is required when --sync is specified")
+			return fmt.Errorf("--url is required when --sync (aliases --discover or --register) is specified")
 		}
 
 		if _, err := neturl.ParseRequestURI(cmd.URL); err != nil {


### PR DESCRIPTION
* Adds --discover and --register as CLI aliases for the --sync flag on the amtinfo command.
* All three flags set the same Sync field and trigger identical behavior: collect full device info and PATCH it to the devices API, auto-registering via POST on 404.
* The aliases are noted in the --sync help text.

Addresses #1406

Description:
All the below 3 commands work:

```
sudo ./rpc amtinfo --sync --url https://<host_ip_addr>:8181/api/v1/devices \
  --auth-endpoint https://<host_ip_addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```

or

```
sudo ./rpc amtinfo --discover --url https://<host_ip_addr>:8181/api/v1/devices \
  --auth-endpoint https://<host_ip_addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```

or

```
sudo ./rpc amtinfo --register --url https://<host_ip_addr>:8181/api/v1/devices \
  --auth-endpoint https://<host_ip_addr>:8181/api/v1/authorize \
  --auth-username <username> --auth-password "<password>" \
  --skip-cert-check --log-level=debug -v
```

To see the synced data,query from host:

```
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize -H "Content-Type: application/json" -d '{"username":"<username>","password":"<password>"}' | jq -r '.token') && curl -sk https://localhost:8181/api/v1/devices -H "Authorization: Bearer $TOKEN" | jq '[.[] | {hostname, guid, deviceInfo}]'
```

You can see the help as well.

```
Display information about AMT status and configuration

Flags:
  -h, --help                       Show context-sensitive help.
      --log-level="info"           Set log level ($RPC_LOG_LEVEL)
  -j, --json                       Output in JSON format ($RPC_JSON)
  -t, --table                      Output in table format ($RPC_TABLE)
      --no-color                   Disable colored output ($NO_COLOR)
  -v, --verbose                    Enable verbose logging ($RPC_VERBOSE)
  -n, --skip-cert-check            Skip certificate verification for remote HTTPS/WSS (RPS) connections (insecure)
                                   ($RPC_SKIP_CERT_CHECK)
      --skip-amt-cert-check        Skip certificate verification when connecting to AMT/LMS over TLS (insecure)
                                   ($RPC_SKIP_AMT_CERT_CHECK)
      --tenantid=STRING            Tenant ID for multi-tenant environments for use with RPS ($TENANT_ID)
      --lmsaddress="localhost"     LMS address to connect to ($RPC_LMSADDRESS)
      --lmsport="16992"            LMS port to connect to ($RPC_LMSPORT)
      --password=STRING            AMT admin password applied globally to all AMT operations ($AMT_PASSWORD)
      --auth-token=STRING          Bearer token for server authentication ($AUTH_TOKEN)
      --auth-username=STRING       Username for basic auth (used when no token) ($AUTH_USERNAME)
      --auth-password=STRING       Password for basic auth (used when no token) ($AUTH_PASSWORD)
      --auth-endpoint=STRING       Token exchange endpoint. Requires --auth-token or --auth-username/--auth-password.
                                   Resolved relative to the profile URL host unless absolute ($AUTH_ENDPOINT).
      --devices-endpoint=STRING    Devices API endpoint (absolute URL). Defaults to {console-url}/api/v1/devices when
                                   not set ($DEVICES_ENDPOINT).

  -r, --ver                        Show AMT Version ($RPC_VER)
  -b, --bld                        Show Build Number ($RPC_BLD)
  -s, --sku                        Show Product SKU ($RPC_SKU)
  -u, --uuid                       Show Unique Identifier ($RPC_UUID)
      --upid                       Show Intel Unique Platform ID ($RPC_UPID)
  -m, --mode                       Show Current Control Mode ($RPC_MODE)
  -p, --provisioningState          Show Provisioning State ($RPC_PROVISIONING_STATE)
  -d, --dns                        Show Domain Name Suffix ($RPC_DNS)
      --hostname                   Show OS Hostname ($RPC_HOSTNAME)
  -l, --lan                        Show LAN Settings ($RPC_LAN)
  -a, --ras                        Show Remote Access Status ($RPC_RAS)
      --operationalState           Show AMT Operational State ($RPC_OPERATIONAL_STATE)
  -c, --cert                       Show System Certificate Hashes ($RPC_CERT)
      --userCert                   Show User Certificates only ($RPC_USER_CERT)
      --proxy                      Show HTTP Proxy Configuration (requires WSMAN) ($RPC_PROXY)
  -A, --all                        Show All AMT Information ($RPC_ALL)
      --sync                       Sync device info to remote server via HTTP PATCH (aliases: --discover, --register)
                                   ($RPC_SYNC)
      --url=STRING                 Endpoint URL of the devices API (e.g., https://mps.example.com/api/v1/devices)
                                   ($RPC_URL)
```
