### PR TITLE
chore: release v3.0.0-beta.43

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2
+	github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hirochachacha/go-smb2 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMF
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2 h1:SWQjsGsU2ATsiDH44GJLrBsC5VcuazhpTtd/wqsAzHc=
-github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2/go.mod h1:qyUtbGy8ylKeKxkwJ+YjBC5sVrdKfLJtnQYCjUEU8to=
+github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3 h1:vVza5m43IfWzvz5hhri7ftQ6n3YwbLq+mEACNi8v55s=
+github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3/go.mod h1:qyUtbGy8ylKeKxkwJ+YjBC5sVrdKfLJtnQYCjUEU8to=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=


### PR DESCRIPTION
## PR Checklist

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

Release `v3.0.0-beta.43`.

- Bumps `github.com/device-management-toolkit/go-wsman-messages/v2` from `v2.48.2` to `v2.48.3` (latest).

## Anything the reviewer should know when reviewing this PR?

Dependency-only change. `go build ./...`, `go vet ./...`, and `go test ./...` all pass locally.

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

Companion release PR on the `2.x.x` branch of this repo.
