### PR TITLE
chore: release v2.52.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25.9
 // replace github.com/device-management-toolkit/go-wsman-messages/v2 => ../go-wsman-messages
 
 require (
-	github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2
+	github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hirochachacha/go-smb2 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMF
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2 h1:SWQjsGsU2ATsiDH44GJLrBsC5VcuazhpTtd/wqsAzHc=
-github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.2/go.mod h1:qyUtbGy8ylKeKxkwJ+YjBC5sVrdKfLJtnQYCjUEU8to=
+github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3 h1:vVza5m43IfWzvz5hhri7ftQ6n3YwbLq+mEACNi8v55s=
+github.com/device-management-toolkit/go-wsman-messages/v2 v2.48.3/go.mod h1:qyUtbGy8ylKeKxkwJ+YjBC5sVrdKfLJtnQYCjUEU8to=
 github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
 github.com/geoffgarside/ber v1.2.0 h1:/loowoRcs/MWLYmGX9QtIAbA+V/FrnVLsMMPhwiRm64=
 github.com/geoffgarside/ber v1.2.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=


### PR DESCRIPTION
## PR Checklist

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

Release `v2.52.3`.

- Bumps `github.com/device-management-toolkit/go-wsman-messages/v2` from `v2.48.2` to `v2.48.3` (latest).

## Anything the reviewer should know when reviewing this PR?

Dependency-only change. `go build ./...`, `go vet ./...`, and `go test ./...` all pass locally.

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )

Companion release PR on the `main` branch of this repo.
