### PR TITLE
ci: sign release binaries with Cosign

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build.sh text eol=lf
+sign.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   release:
     permissions:
       contents: write # for Git to git push
+      id-token: write # for Cosign keyless signing (Fulcio/OIDC)
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -53,6 +54,11 @@ jobs:
         run: |
           go install github.com/google/go-licenses@v1.0.0
           echo "PATH=$PATH:$(go env GOPATH)/bin" >> $GITHUB_ENV
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: 'v3.0.2'
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@c4a2fa890676fc2db25ad0aacd8ab4a0f1f4c024 # v4.2.1

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -48,6 +48,18 @@
           {
             "path": "licenses.zip",
             "label": "Third-party Licenses"
+          },
+          {
+            "path": "*.cosign.bundle.json",
+            "label": "Cosign Signature Bundles"
+          },
+          {
+            "path": "*.sig",
+            "label": "Cosign Signatures"
+          },
+          {
+            "path": "*.pem",
+            "label": "Cosign Signing Certificates"
           }
         ]
       }
@@ -55,7 +67,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "./build.sh ${nextRelease.version} && docker build -t vprodemo.azurecr.io/rpc-go:v${nextRelease.version} -t vprodemo.azurecr.io/rpc-go:latest -t docker.io/intel/oact-rpc-go:v${nextRelease.version} -t docker.io/intel/oact-rpc-go:latest -t docker.io/intel/device-mgmt-toolkit-rpc-go:v${nextRelease.version} -t docker.io/intel/device-mgmt-toolkit-rpc-go:latest .",
+        "prepareCmd": "./build.sh ${nextRelease.version} && ./sign.sh && docker build -t vprodemo.azurecr.io/rpc-go:v${nextRelease.version} -t vprodemo.azurecr.io/rpc-go:latest -t docker.io/intel/oact-rpc-go:v${nextRelease.version} -t docker.io/intel/oact-rpc-go:latest -t docker.io/intel/device-mgmt-toolkit-rpc-go:v${nextRelease.version} -t docker.io/intel/device-mgmt-toolkit-rpc-go:latest .",
         "publishCmd": "docker push vprodemo.azurecr.io/rpc-go:v${nextRelease.version} && docker push vprodemo.azurecr.io/rpc-go:latest && docker push docker.io/intel/oact-rpc-go:v${nextRelease.version} && docker push docker.io/intel/oact-rpc-go:latest && docker push docker.io/intel/device-mgmt-toolkit-rpc-go:v${nextRelease.version} && docker push docker.io/intel/device-mgmt-toolkit-rpc-go:latest",
         "verifyReleaseCmd": "echo v${nextRelease.version} > .nextVersion"
       }

--- a/sign.sh
+++ b/sign.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Sign the release binaries with Cosign using keyless (Fulcio/OIDC) signing.
+#
+# Reference: orch-ci .github/actions/security/cosign (sigstore/cosign).
+# In CI this relies on the ambient GitHub Actions OIDC token, so the calling
+# workflow must grant `id-token: write` and have cosign installed
+# (sigstore/cosign-installer). For each artifact this emits a detached
+# signature (.sig), the signing certificate (.pem) and a Sigstore bundle
+# (.cosign.bundle.json) that pairs the two for offline `cosign verify-blob`.
+#
+# After signing, each artifact is verified with `cosign verify-blob` (as the
+# orch-ci action does) so a bad signature fails the release instead of
+# shipping. The verified identity is this repo's release workflow via the
+# GitHub Actions OIDC issuer. Set COSIGN_SKIP_VERIFY=1 to skip verification
+# (e.g. local key-based testing, where there is no Fulcio identity to match).
+
+set -euo pipefail
+
+# Keyless verification identity. GITHUB_REPOSITORY is set by GitHub Actions;
+# fall back to the canonical repo for local runs.
+repo="${GITHUB_REPOSITORY:-device-management-toolkit/rpc-go}"
+cert_identity_regexp="https://github.com/${repo}/.github/workflows/.*.yml@.*"
+oidc_issuer="https://token.actions.githubusercontent.com"
+
+# The release artifacts produced by build.sh (see .releaserc.json assets).
+artifacts=(
+    rpc_linux_x64.tar.gz
+    rpc_linux_x86.tar.gz
+    rpc_windows_x64.exe
+    rpc_windows_x86.exe
+    rpc_so_x64.tar.gz
+)
+
+for artifact in "${artifacts[@]}"; do
+    if [ ! -f "$artifact" ]; then
+        echo "❌ Artifact not found, cannot sign: $artifact"
+        exit 1
+    fi
+
+    echo "──────────────────────────────"
+    echo "🔏 Signing binary: $artifact"
+    echo "──────────────────────────────"
+
+    cosign sign-blob \
+        --yes \
+        --bundle "${artifact}.cosign.bundle.json" \
+        --output-signature "${artifact}.sig" \
+        --output-certificate "${artifact}.pem" \
+        "$artifact"
+
+    echo "✅ Signed $artifact"
+
+    if [ "${COSIGN_SKIP_VERIFY:-0}" = "1" ]; then
+        echo "⏭️  Skipping verification (COSIGN_SKIP_VERIFY=1) for $artifact"
+        continue
+    fi
+
+    echo "🧾 Verifying $artifact"
+    cosign verify-blob \
+        --bundle "${artifact}.cosign.bundle.json" \
+        --certificate-identity-regexp "$cert_identity_regexp" \
+        --certificate-oidc-issuer "$oidc_issuer" \
+        "$artifact"
+    echo "🟢 Verified $artifact"
+done
+
+echo "Cosign artifacts:"
+ls -lh ./*.sig ./*.pem ./*.cosign.bundle.json || true


### PR DESCRIPTION
- Backports Cosign artifact signing to the 2.x.x release pipeline.
- Updates 2.x.x release config to include signing outputs in release assets.
- Adds CI setup for Cosign with OIDC-based keyless signing.
- Keeps existing 2.x.x release behavior otherwise unchanged.