### PR TITLE
refactor: use NewLazySystemDLL for known system DLL loads

### DIFF
--- a/pkg/utils/privilege_windows.go
+++ b/pkg/utils/privilege_windows.go
@@ -92,7 +92,7 @@ func SelfElevate() error {
 	}
 	sei.cbSize = uint32(unsafe.Sizeof(sei))
 
-	shell32 := windows.NewLazyDLL("shell32.dll")
+	shell32 := windows.NewLazySystemDLL("shell32.dll")
 	shellExecuteEx := shell32.NewProc("ShellExecuteExW")
 
 	r, _, sysErr := shellExecuteEx.Call(uintptr(unsafe.Pointer(&sei)))

--- a/pkg/windows/setupapi.go
+++ b/pkg/windows/setupapi.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	modsetupapi = syscall.NewLazyDLL("setupapi.dll")
+	modsetupapi = windows.NewLazySystemDLL("setupapi.dll")
 
 	procSetupDiGetClassDevsW              = modsetupapi.NewProc("SetupDiGetClassDevsW")
 	procSetupDiGetDeviceRegistryPropertyW = modsetupapi.NewProc("SetupDiGetDeviceRegistryPropertyW")


### PR DESCRIPTION
## Summary
Fixes DLL search order hijacking vulnerability 

## Problem
`syscall.NewLazyDLL("setupapi.dll")` resolves DLLs via the standard Windows
search order, which includes the current directory before System32. Since rpc
runs as administrator, an attacker with write access to the working directory
could load a malicious `setupapi.dll` instead of the legitimate system DLL.

## Fix
```go
// Before
modsetupapi = syscall.NewLazyDLL("setupapi.dll")

// After
modsetupapi = windows.NewLazySystemDLL("setupapi.dll")
```

# Test
Tested on Windows using **Process Monitor (Sysinternals)**. With the fix applied (`windows.NewLazySystemDLL`), the DLL load path is confirmed as `C:\Windows\System32\setupapi.dll` — loaded directly from System32 only, with no search through the application directory or PATH entries. 

<img width="500" height="377" alt="Screenshot 2026-08-04 104800" src="https://github.com/user-attachments/assets/64db3d94-c9f0-470b-befc-d5dff27fb0a6" />

<img width="531" height="142" alt="Screenshot 2026-08-04 104834" src="https://github.com/user-attachments/assets/8f927c9c-a949-42b1-9602-608bd0838c6b" />
